### PR TITLE
Make css_to_xpath more compatible with location paths.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,12 @@ Features added
 Bugs fixed
 ----------
 
+* In lxml.cssselect, use the xpath 'A//B' (short for
+  'A/descendant-or-self::node()/B') instead of 'A/descendant::B' for the css
+  descendant selector ('A B'). This makes a few edge cases to be consistent
+  with the selector behavior in WebKit and Firefox, and makes more css
+  expressions valid location paths (for use in xsl:template match).
+
 * In lxml.html, non-selected ``<option>`` tags no longer show up in the
   collected form values.
 

--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -494,7 +494,7 @@ class CombinedSelector(object):
 
     def _xpath_descendant(self, xpath, sub):
         # when sub is a descendant in any way of xpath
-        xpath.join('/descendant::', sub.xpath())
+        xpath.join('//', sub.xpath())
         return xpath
     
     def _xpath_child(self, xpath, sub):

--- a/src/lxml/tests/test_css.txt
+++ b/src/lxml/tests/test_css.txt
@@ -95,7 +95,7 @@ Now of translation:
     >>> xpath('E:nth-last-of-type(1)')
     */e[position() = last() - 1]
     >>> xpath('div E:nth-last-of-type(1) .aclass')
-    div/descendant::e[position() = last() - 1]/descendant::*[contains(concat(' ', normalize-space(@class), ' '), ' aclass ')]
+    div//e[position() = last() - 1]//*[contains(concat(' ', normalize-space(@class), ' '), ' aclass ')]
     >>> xpath('E:first-child')
     */*[name() = 'e' and (position() = 1)]
     >>> xpath('E:last-child')
@@ -119,7 +119,7 @@ Now of translation:
     >>> xpath('E:not(:contains("foo"))')
     e[not(contains(css:lower-case(string(.)), 'foo'))]
     >>> xpath('E F')
-    e/descendant::f
+    e//f
     >>> xpath('E > F')
     e/f
     >>> xpath('E + F')
@@ -127,7 +127,7 @@ Now of translation:
     >>> xpath('E ~ F')
     e/following-sibling::f
     >>> xpath('div#container p')
-    div[@id = 'container']/descendant::p
+    div[@id = 'container']//p
     >>> xpath('p *:only-of-type')
     Traceback (most recent call last):
         ...

--- a/src/lxml/tests/test_css_select.txt
+++ b/src/lxml/tests/test_css_select.txt
@@ -112,7 +112,7 @@ Now, the tests:
     >>> pcss('li div:only-child')
     li-div
     >>> pcss('div *:only-child')
-    foobar-span
+    li-div, foobar-span
     >>> pcss('p *:only-of-type')
     Traceback (most recent call last):
         ...
@@ -146,5 +146,7 @@ Now, the tests:
     tag-anchor, nofollow-anchor
     >>> pcss('a[rel="tag"] ~ a')
     nofollow-anchor
-    >>> pcss('ol#first-ol li:last-child', 'ol#first-ol *:last-child')
+    >>> pcss('ol#first-ol li:last-child')
     seventh-li
+    >>> pcss('ol#first-ol *:last-child')
+    li-div, seventh-li


### PR DESCRIPTION
In lxml.cssselect, use the xpath 'A//B' (short for
'A/descendant-or-self::node()/B') instead of 'A/descendant::B' for the css
descendant selector ('A B'). This makes a few edge cases to be consistent
with the selector behavior in WebKit and Firefox, and makes more css
expressions valid location paths (for use in xsl:template match).

Refs https://bugs.launchpad.net/lxml/+bug/657968
