### PR TITLE
Static builds may specify the download directory.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -54,6 +54,7 @@ Bugs fixed
 Other changes
 --------------
 
+* Static builds may specify the download directory.
 
 2.3 (2011-02-06)
 ================

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -44,10 +44,10 @@ def ext_modules(static_include_dirs, static_library_dirs,
         from buildlibxml import build_libxml2xslt, get_prebuilt_libxml2xslt
         if sys.platform.startswith('win'):
             get_prebuilt_libxml2xslt(
-                'libs', static_include_dirs, static_library_dirs)
+                OPTION_DOWNLOAD_DIR, static_include_dirs, static_library_dirs)
         else:
             XML2_CONFIG, XSLT_CONFIG = build_libxml2xslt(
-                'libs', 'build/tmp',
+                OPTION_DOWNLOAD_DIR, 'build/tmp',
                 static_include_dirs, static_library_dirs,
                 static_cflags, static_binaries,
                 libiconv_version=OPTION_LIBICONV_VERSION,
@@ -355,3 +355,6 @@ OPTION_LIBXML2_VERSION = option_value('libxml2-version')
 OPTION_LIBXSLT_VERSION = option_value('libxslt-version')
 OPTION_LIBICONV_VERSION = option_value('libiconv-version')
 OPTION_MULTICORE = option_value('multicore')
+OPTION_DOWNLOAD_DIR = option_value('download-dir')
+if OPTION_DOWNLOAD_DIR is None:
+    OPTION_DOWNLOAD_DIR = 'libs'


### PR DESCRIPTION
Currently static builds look in 'libs' for downloads. This patch makes that directory configurable using the DOWNLOAD_DIR environment variable or the --download-dir= command line option.

When using zc.buildout eggs, are built in a temporary directory, making it impossible to supply lxml with the appropriate tarballs. I would rather use the inbuilt static build support rather than resort to z3c.recipe.staticlxml. After downloading the tarballs to the appropriate location, with this change I can now specify:

```
[lxml]
recipe = zc.recipe.egg:custom
egg = lxml
environment = lxml-env

[lxml-env]
STATIC_DEPS = true
DOWNLOAD_DIR = ${buildout:directory}/lxmldownloads
LIBXML2_VERSION = 2.7.8
LIBXSLT_VERSION = 1.1.26
LIBICONV_VERSION = 1.14
```
