### PR TITLE
fix issues with moving the tail after a node has been removed

### DIFF
--- a/src/lxml/ElementInclude.py
+++ b/src/lxml/ElementInclude.py
@@ -204,7 +204,8 @@ def _include(elem, loader=None, _parent_hrefs=None, base_url=None):
                 elif parent is None:
                     return text # replaced the root node!
                 else:
-                    parent.text = (parent.text or "") + text + (e.tail or "")
+                    parent.text = (parent.text or "") + text 
+
                 parent.remove(e)
             else:
                 raise FatalIncludeError(

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -820,8 +820,8 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
         if c_node.parent is not self._c_node:
             raise ValueError, u"Element is not a child of this node."
         c_next = element._c_node.next
-        tree.xmlUnlinkNode(c_node)
         _moveTail(c_next, c_node)
+        tree.xmlUnlinkNode(c_node)
         # fix namespace declarations
         moveNodeToDocument(self._doc, c_node.doc, c_node)
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -2698,6 +2698,42 @@ class ETreeOnlyTestCase(HelperTestCase):
         result = tostring(a, with_tail=True)
         self.assertEquals(result, _bytes("<a><b/>bTAIL<c/></a>aTAIL"))
 
+    def test_remove_tail(self):
+        tostring = self.etree.tostring
+        Element = self.etree.Element
+        SubElement = self.etree.SubElement
+
+        a = Element('a')
+        a.text = "aTEXT"
+        a.tail = "aTAIL"
+        b = SubElement(a, 'b')
+        b.text = "bTEXT"
+        b.tail = "bTAIL"
+
+        a.remove(b)
+
+        result = tostring(a, with_tail=True)
+        self.assertEquals(result, _bytes("<a>aTEXTbTAIL</a>aTAIL"))
+
+    def test_remove_nested_tail(self):
+        tostring = self.etree.tostring
+        Element = self.etree.Element
+        SubElement = self.etree.SubElement
+
+        a = Element('a')
+        a.tail = "aTAIL"
+        b = SubElement(a, 'b')
+        b.text = "bTEXT"
+        b.tail = "bTAIL"
+        c = SubElement(a, 'c')
+        c.text = "cTEXT"
+        c.tail = "cTAIL"
+
+        a.remove(b)
+
+        result = tostring(a, with_tail=True)
+        self.assertEquals(result, _bytes("<a>bTAIL<c>cTEXT</c>cTAIL</a>aTAIL"))
+
     def test_standalone(self):
         tostring = self.etree.tostring
         XML = self.etree.XML


### PR DESCRIPTION
After fixing the initial line for moving the tail after it has been removed, the code for ElementInclude was affected and broke the test.  After more investigation, it appears that the initial bug was compounded by recovering the tail manually through appending it to the parent.text.  Now all tests appear to pass.
