### PR TITLE
Added support for passing kwargs into html5lib parser. I.e lxml.html.html

### DIFF
--- a/src/lxml/html/html5parser.py
+++ b/src/lxml/html/html5parser.py
@@ -20,8 +20,8 @@ except NameError:
 class HTMLParser(_HTMLParser):
     """An html5lib HTML parser with lxml as tree."""
 
-    def __init__(self, strict=False):
-        _HTMLParser.__init__(self, strict=strict, tree=TreeBuilder)
+    def __init__(self, strict=False, **kwargs):
+        _HTMLParser.__init__(self, strict=strict, tree=TreeBuilder, **kwargs)
 
 
 try:
@@ -32,8 +32,8 @@ else:
     class XHTMLParser(_XHTMLParser):
         """An html5lib XHTML Parser with lxml as tree."""
 
-        def __init__(self, strict=False):
-            _XHTMLParser.__init__(self, strict=strict, tree=TreeBuilder)
+        def __init__(self, strict=False, **kwargs):
+            _XHTMLParser.__init__(self, strict=strict, tree=TreeBuilder, **kwargs)
 
     xhtml_parser = XHTMLParser()
 


### PR DESCRIPTION
Added support for passing kwargs into html5lib parser. I.e lxml.html.html5parser.HTMLParser(namespaceHTMLElements=False) which is needed in order to avoid the html:div namespacing.
