### PR TITLE
"E :pseudo" should parse the same as "E *:pseudo", not "E:pseudo" 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,12 @@ Bugs fixed
 * lxml.html.diff no longer raises an exception when hitting
   'img' tags without 'src' attribute.
 
+* Fixed parsing of more selectors in cssselect. Whitespace before
+  pseudo-elements and pseudo-classes is significant. (It is a descendant
+  combinator.)
+  "E :pseudo" should parse the same as "E *:pseudo", not "E:pseudo".
+  Patch by Simon Sapin.
+
 Other changes
 --------------
 

--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -909,11 +909,13 @@ def tokenize(s):
         c = s[pos]
         c2 = s[pos:pos+2]
         if c2 in ('~=', '|=', '^=', '$=', '*=', '::', '!='):
+            if c2 == '::' and preceding_whitespace_pos > 0:
+                yield Token(' ', preceding_whitespace_pos)
             yield Token(c2, pos)
             pos += 2
             continue
         if c in '>+~,.*=[]()|:#':
-            if c in '.#[' and preceding_whitespace_pos > 0:
+            if c in ':.#[' and preceding_whitespace_pos > 0:
                 yield Token(' ', preceding_whitespace_pos)
             yield Token(c, pos)
             pos += 1

--- a/src/lxml/tests/test_css.txt
+++ b/src/lxml/tests/test_css.txt
@@ -34,6 +34,12 @@ Then of parsing:
     CombinedSelector[Element[div] > Class[Element[*].foo]]
     >>> parse('td:first')
     Pseudo[Element[td]:first]
+    >>> parse('td::first')
+    Pseudo[Element[td]::first]
+    >>> parse('td :first')
+    CombinedSelector[Element[td] <followed> Pseudo[Element[*]:first]]
+    >>> parse('td ::first')
+    CombinedSelector[Element[td] <followed> Pseudo[Element[*]::first]]
     >>> parse('a[name]')
     Attrib[Element[a][name]]
     >>> parse('a [name]')

--- a/src/lxml/tests/test_css_select.txt
+++ b/src/lxml/tests/test_css_select.txt
@@ -152,3 +152,7 @@ Now, the tests:
     seventh-li
     >>> pcss('ol#first-ol *:last-child')
     li-div, seventh-li
+    >>> pcss('#outer-div:first-child')
+    outer-div
+    >>> pcss('#outer-div :first-child')
+    name-anchor, first-li, li-div, p-b


### PR DESCRIPTION
One more bug fix for whitespace handling in the tokenizer/parser for CSS selectors.

Stephan, I took the liberty to add my name in the changelog since you did it for the previous patch.
