### PR TITLE
change PyFile_AsFile signature to omit generated ref counting

### DIFF
--- a/src/lxml/iterparse.pxi
+++ b/src/lxml/iterparse.pxi
@@ -496,7 +496,7 @@ cdef class iterparse(_BaseParser):
         events = context._events
         del events[:]
         context._event_index = 0
-        c_stream = python.PyFile_AsFile(self._source)
+        c_stream = python.PyFile_AsFile(<python.PyObject* >self._source)
         while not events:
             if c_stream is NULL:
                 data = self._source.read(__ITERPARSE_CHUNK_SIZE)

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -302,7 +302,7 @@ cdef class _FileReaderContext:
         cdef cstd.FILE* c_stream
         cdef xmlparser.xmlParserInputBuffer* c_buffer
         c_buffer = xmlparser.xmlAllocParserInputBuffer(0)
-        c_stream = python.PyFile_AsFile(self._filelike)
+        c_stream = python.PyFile_AsFile(<python.PyObject* >self._filelike)
         if c_stream is NULL:
             c_buffer.readcallback  = _readFilelikeParser
             c_buffer.context = <python.PyObject*>self
@@ -336,7 +336,7 @@ cdef class _FileReaderContext:
         else:
             c_encoding = _cstr(self._encoding)
 
-        c_stream = python.PyFile_AsFile(self._filelike)
+        c_stream = python.PyFile_AsFile(<python.PyObject* >self._filelike)
         if c_stream is NULL:
             c_read_callback  = _readFilelikeParser
             c_callback_context = <python.PyObject*>self

--- a/src/lxml/python.pxd
+++ b/src/lxml/python.pxd
@@ -12,7 +12,7 @@ cdef extern from "Python.h":
     cdef void Py_DECREF(object o)
     cdef void Py_XDECREF(PyObject* o)
 
-    cdef FILE* PyFile_AsFile(object p)
+    cdef FILE* PyFile_AsFile(PyObject* p)
 
     cdef bint PyUnicode_Check(object obj)
     cdef bint PyUnicode_CheckExact(object obj)

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -533,7 +533,7 @@ cdef _tofilelikeC14N(f, _Element element, bint exclusive, bint with_comments,
 cdef _dumpToFile(f, xmlNode* c_node, bint pretty_print, bint with_tail):
     cdef tree.xmlOutputBuffer* c_buffer
     cdef cstd.FILE* c_file
-    c_file = python.PyFile_AsFile(f)
+    c_file = python.PyFile_AsFile(<python.PyObject* >f)
     if c_file is NULL:
         raise ValueError, u"not a file"
     c_buffer = tree.xmlOutputBufferCreateFile(c_file, NULL)


### PR DESCRIPTION
The previous definition led cython to generate reference counting when
PyFile_AsFile() was called, like the below:

```
__pyx_t_1 = __pyx_v_self->_source;
__Pyx_INCREF(__pyx_t_1);
__pyx_v_c_stream = PyFile_AsFile(__pyx_t_1);
__Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
```

Modify its signature such that ref counting is not generated, which
should be the case (the function simply dereferences a member of the
file struct).
