### PR TITLE
Make the removed CSS contains selector case sensitive

### DIFF
--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -238,11 +238,12 @@ class Function(object):
 
     def _xpath_contains(self, xpath, expr):
         # text content, minus tags, must contain expr
+        # this selector was removed from the CSS3 spec
+        # case sensitive for speed, matching jQuery's implementation
         if isinstance(expr, Element):
             expr = expr._format_element()
-        xpath.add_condition('contains(css:lower-case(string(.)), %s)'
-                            % xpath_literal(expr.lower()))
-        # FIXME: Currently case insensitive matching doesn't seem to be happening
+        xpath.add_condition('contains(string(.), %s)'
+                            % xpath_literal(expr))
         return xpath
 
     def _xpath_not(self, xpath, expr):
@@ -252,13 +253,6 @@ class Function(object):
         # FIXME: should I do something about element_path?
         xpath.add_condition('not(%s)' % cond)
         return xpath
-
-def _make_lower_case(context, s):
-    return s.lower()
-
-ns = etree.FunctionNamespace('http://codespeak.net/lxml/css/')
-ns.prefix = 'css'
-ns['lower-case'] = _make_lower_case
 
 class Pseudo(object):
     """

--- a/src/lxml/tests/test_css.py
+++ b/src/lxml/tests/test_css.py
@@ -24,7 +24,7 @@ class CSSTestCase(HelperTestCase):
         ## Changed from original, because the original doesn't make sense.
         ## There really aren't that many occurrances of 'celia'
         #('div:contains(CELIA)', 243),
-        ('div:contains(CELIA)', 30),
+        ('div:contains(CELIA)', 26),
         ('div:nth-child(even)', 106),
         ('div:nth-child(2n)', 106),
         ('div:nth-child(odd)', 137),

--- a/src/lxml/tests/test_css.txt
+++ b/src/lxml/tests/test_css.txt
@@ -129,13 +129,13 @@ Now of translation:
     >>> xpath('E:root')
     e[not(parent::*)]
     >>> xpath('E:contains("foo")')
-    e[contains(css:lower-case(string(.)), 'foo')]
+    e[contains(string(.), 'foo')]
     >>> xpath('E.warning')
     e[contains(concat(' ', normalize-space(@class), ' '), ' warning ')]
     >>> xpath('E#myid')
     e[@id = 'myid']
     >>> xpath('E:not(:contains("foo"))')
-    e[not(contains(css:lower-case(string(.)), 'foo'))]
+    e[not(contains(string(.), 'foo'))]
     >>> xpath('E F')
     e/descendant-or-self::*/f
     >>> xpath('E > F')

--- a/src/lxml/tests/test_css_select.txt
+++ b/src/lxml/tests/test_css_select.txt
@@ -129,7 +129,7 @@ Now, the tests:
     empty
     >>> pcss('*:contains("link")')
     html, nil, outer-div, tag-anchor, nofollow-anchor
-    >>> pcss('*:contains("E")')
+    >>> pcss('*:contains("e")')
     html, nil, outer-div, first-ol, first-li, paragraph, p-em
     >>> pcss('.a', '.b', '*.a', 'ol.a')
     first-ol


### PR DESCRIPTION
The contains CSS selector was removed from the spec. Make it case sensitive for simplicity, speed and to match jQuery's implementation.
