### PR TITLE
Change cssselect's globally registered namespace prefix

### DIFF
--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -240,7 +240,7 @@ class Function(object):
         # text content, minus tags, must contain expr
         if isinstance(expr, Element):
             expr = expr._format_element()
-        xpath.add_condition('contains(css:lower-case(string(.)), %s)'
+        xpath.add_condition('contains(lxml_cssselect:lower-case(string(.)), %s)'
                             % xpath_literal(expr.lower()))
         # FIXME: Currently case insensitive matching doesn't seem to be happening
         return xpath
@@ -257,7 +257,7 @@ def _make_lower_case(context, s):
     return s.lower()
 
 ns = etree.FunctionNamespace('http://codespeak.net/lxml/css/')
-ns.prefix = 'css'
+ns.prefix = 'lxml_cssselect'
 ns['lower-case'] = _make_lower_case
 
 class Pseudo(object):

--- a/src/lxml/tests/test_css.txt
+++ b/src/lxml/tests/test_css.txt
@@ -129,13 +129,13 @@ Now of translation:
     >>> xpath('E:root')
     e[not(parent::*)]
     >>> xpath('E:contains("foo")')
-    e[contains(css:lower-case(string(.)), 'foo')]
+    e[contains(lxml_cssselect:lower-case(string(.)), 'foo')]
     >>> xpath('E.warning')
     e[@class and contains(concat(' ', normalize-space(@class), ' '), ' warning ')]
     >>> xpath('E#myid')
     e[@id = 'myid']
     >>> xpath('E:not(:contains("foo"))')
-    e[not(contains(css:lower-case(string(.)), 'foo'))]
+    e[not(contains(lxml_cssselect:lower-case(string(.)), 'foo'))]
     >>> xpath('E F')
     e/descendant-or-self::*/f
     >>> xpath('E > F')


### PR DESCRIPTION
from `css` to `lxml_cssselect` to avoid unexpected clashes with user xml, e.g. with lxml 2.3.4:

```
>>> from lxml import etree
>>> doc = etree.XML('<a xmlns:css="local://css"><b css:foo="bar"/></a>')
>>> doc.xpath('//*[@css:foo]', namespaces=dict(css="local://css"))
[<Element b at 0x100790d20>]
>>> import lxml.cssselect
>>> doc.xpath('//*[@css:foo]', namespaces=dict(css="local://css"))
[]
```
