### PR TITLE
e.args is intended to be a tuple with a single item.

### DIFF
--- a/src/lxml/tests/test_css.py
+++ b/src/lxml/tests/test_css.py
@@ -92,7 +92,7 @@ class CSSTestCase(HelperTestCase):
             results = body.xpath(xpath)
         except Exception:
             e = sys.exc_info()[1]
-            e.args = ("%s for xpath %r" % (e, xpath))
+            e.args = ("%s for xpath %r" % (e, xpath),)
             raise
         found = {}
         for item in results:


### PR DESCRIPTION
Fixes formatting during test failure.
