### PR TITLE
Ignore whitespace after a CSS group separator.

### DIFF
--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -709,6 +709,9 @@ def parse_selector_group(stream):
         result.append(parse_selector(stream))
         if stream.peek() == ',':
             stream.next()
+            # Ignore optional whitespace after a group separator
+            while stream.peek() == ' ':
+                stream.next()
         else:
             break
     if len(result) == 1:

--- a/src/lxml/tests/test_css.txt
+++ b/src/lxml/tests/test_css.txt
@@ -23,14 +23,14 @@ Then of parsing:
     ...         other_result = repr(parse(other))
     ...         if other_result != result:
     ...             print('Selector %r parses as\n%s' % (other, other_result))
-    >>> parse('td.foo, .bar')
-    Or([Class[Element[td].foo], CombinedSelector[Element[*] <followed> Class[Element[*].bar]]])
+    >>> parse_many('td.foo,.bar', 'td.foo, .bar', 'td.foo\t\r\n\f ,\t\r\n\f .bar')
+    Or([Class[Element[td].foo], Class[Element[*].bar]])
     >>> parse('div, td.foo, div.bar span')
     Or([Element[div], Class[Element[td].foo], CombinedSelector[Class[Element[div].bar] <followed> Element[span]]])
     >>> parse('div > p')
     CombinedSelector[Element[div] > Element[p]]
     >>> parse_many('div>.foo', 'div> .foo', 'div >.foo', 'div > .foo',
-    ...            'div \n>  \t \t .foo', 'div\r>\n\n\n.foo')
+    ...            'div \n>  \t \t .foo', 'div\r>\n\n\n.foo', 'div\f>\f.foo')
     CombinedSelector[Element[div] > Class[Element[*].foo]]
     >>> parse('td:first')
     Pseudo[Element[td]:first]


### PR DESCRIPTION
Fix horrific performance bug by ensuring 'td.foo, .bar' parses the same as 'td.foo,.bar'.
