### PR TITLE
Add a cssselect method to all elements, not just HtmlElement

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -503,7 +503,8 @@ class HtmlComment(etree.CommentBase, HtmlMixin):
     pass
 
 class HtmlElement(etree.ElementBase, HtmlMixin):
-    pass
+    # Override etree.ElementBase.cssselect, despite the MRO
+    cssselect = HtmlMixin.cssselect
 
 class HtmlProcessingInstruction(etree.PIBase, HtmlMixin):
     pass

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -1449,6 +1449,20 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
                                           smart_strings=smart_strings)
         return evaluator(_path, **_variables)
 
+    def cssselect(self, expr, *, translator='xml'):
+        """
+        Run the CSS expression on this element and its children,
+        returning a list of the results.
+
+        Equivalent to lxml.cssselect.CSSSelect(expr)(self) -- note
+        that pre-compiling the expression can provide a substantial
+        speedup.
+        """
+        # Do the import here to make the dependency optional.
+        from lxml.cssselect import CSSSelector
+        return CSSSelector(expr, translator=translator)(self)
+
+
 
 cdef extern from "etree_defs.h":
     # macro call to 't->tp_new()' for fast instantiation


### PR DESCRIPTION
Submit #47 again, without all the clutter from #46.

This is a partial fix for #45. (Elements get a `cssselect()` method but are still not known to be HTML. You might need to pass `translator='html'`.)

@scoder already [commented](https://github.com/lxml/lxml/pull/47#commitcomment-1237759) on two downsides:
- It suggests bad practices for efficiency (the selector is compiled on every call)
- It is too tightly integrated for something that needs an optional, external library

I think that both of these issues can be addressed with documentation, and the convenience can be worth it in some cases. (For example, pre-compiling will not help a selector that is used only once in a test suite.)
