### PR TITLE
Fix documentation link to etreepublic.pxd

### DIFF
--- a/doc/capi.txt
+++ b/doc/capi.txt
@@ -9,7 +9,7 @@ without going through the Python API.
 The API is described in the file `etreepublic.pxd`_, which is directly
 c-importable by extension modules implemented in Pyrex_ or Cython_.
 
-.. _`etreepublic.pxd`: https://github.com/lxml/lxml/blob/master/src/lxml/etreepublic.pxd
+.. _`etreepublic.pxd`: https://github.com/lxml/lxml/blob/master/src/lxml/include/etreepublic.pxd
 .. _Cython: http://cython.org
 .. _Pyrex: http://www.cosc.canterbury.ac.nz/~greg/python/Pyrex/
 


### PR DESCRIPTION
The file has moved to src/lxml/include in
6d33615e46e4a2316331c1bfe8051875abf59ed3
