### PR TITLE
Fix lxml.cssselect for cssselect 0.7

### DIFF
--- a/src/lxml/cssselect.py
+++ b/src/lxml/cssselect.py
@@ -32,10 +32,16 @@ class LxmlTranslator(external_cssselect.GenericTranslator):
     A custom CSS selector to XPath translator with lxml-specific extensions.
     """
     def xpath_contains_function(self, xpath, function):
-        xpath.add_condition(
+        # Defined there, removed in later drafts:
+    # http://www.w3.org/TR/2001/CR-css3-selectors-20011113/#content-selectors
+        if function.argument_types() not in (['STRING'], ['IDENT']):
+            raise ExpressionError(
+                "Expected a single string or ident for :contains(), got %r"
+                % function.arguments)
+        value = function.arguments[0].value
+        return xpath.add_condition(
             'contains(__lxml_internal_css:lower-case(string(.)), %s)'
-            % self.xpath_literal(function.arguments.lower()))
-        return xpath
+            % self.xpath_literal(value.lower()))
 
 
 class LxmlHTMLTranslator(LxmlTranslator, external_cssselect.HTMLTranslator):


### PR DESCRIPTION
lxml uses an undocumented API that changed in 0.7:
`arguments` on functional pseudo-classes objects is now
a list on tokens instead of a single string.
