### PR TITLE
fix exception handling in attribute comparison

### DIFF
--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -2295,13 +2295,16 @@ cdef class _Attrib:
         return 1 if tree.xmlHasNsProp(c_node, _cstr(tag), c_href) else 0
 
     def __richcmp__(one, other, int op):
+        if not isinstance(one, dict):
+            try:
+                one = dict(one)
+            except (TypeError, ValueError):
+                pass
         if not isinstance(other, dict):
             try:
                 other = dict(other)
             except (TypeError, ValueError):
-                return False
-        if not isinstance(one, dict):
-            one = dict(one)
+                pass
         return python.PyObject_RichCompare(one, other, op)
 
 


### PR DESCRIPTION
Handle dumb comparisons between _Attrib and non-dict-like objects.
Return false for comparisons to objects that fail convert to dict.

There may be a better/faster/more efficient way to do this in cython (not so familiar with it), but this fixed my issue. I thought about testing the 'other' object for dict-likeness, but it isn't super easy as it not only has to be iterable but an iterable of iterables of length 2 unless it's already a dict or dict subclass... EAFP right?
