### PR TITLE
fix etree.tostring docstring to match signature

### DIFF
--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -3011,7 +3011,7 @@ def tostring(element_or_tree, *, encoding=None, method=u"xml",
     u"""tostring(element_or_tree, encoding=None, method="xml",
                  xml_declaration=None, pretty_print=False, with_tail=True,
                  standalone=None, doctype=None,
-                 exclusive=False, with_comments=True, inclusive_ns_prefixes)
+                 exclusive=False, with_comments=True, inclusive_ns_prefixes=None)
 
     Serialize an element to an encoded string representation of its XML
     tree.


### PR DESCRIPTION
The default value of the last argument of lxml.etree.tostring, namely  `inclusive_ns_prefixes=True` is omitted from the docstring. This confuses e.g. PyCharms code completion about the required arguments. 

The attached diff changes the docstring to match the function signature.
