### PR TITLE
Incremental serializer: fix attributes

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -705,12 +705,12 @@ cdef class _IncrementalFileWriter:
                 attrib = attrib.items()
             for name, value in attrib:
                 if name not in _extra:
-                    ns, tag = _getNsTag(name)
-                    attributes.append((ns, tag, value))
+                    ns, name = _getNsTag(name)
+                    attributes.append((ns, name, _utf8(value)))
         if _extra:
             for name, value in _extra.iteritems():
-                ns, tag = _getNsTag(name)
-                attributes.append((ns, tag, value))
+                ns, name = _getNsTag(name)
+                attributes.append((ns, name, _utf8(value)))
         if nsmap:
             nsmap = { _utf8(ns) : (_utf8(prefix) if prefix else None)
                       for prefix, ns in nsmap.items() }

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -76,6 +76,27 @@ class _XmlFileTestCaseBase(HelperTestCase):
                 pass
         self.assertXml('<?pypi ?><test></test>')
 
+    def test_comment(self):
+        with etree.xmlfile(self._file) as xf:
+            xf.write(etree.Comment('a comment'))
+            with xf.element('test'):
+                pass
+        self.assertXml('<!--a comment--><test></test>')
+
+    def test_attribute(self):
+        with etree.xmlfile(self._file) as xf:
+            with xf.element('test', attrib={'k': 'v'}):
+                pass
+        self.assertXml('<test k="v"></test>')
+
+    def test_escaping(self):
+        with etree.xmlfile(self._file) as xf:
+            with xf.element('test'):
+                xf.write('Comments: <!-- text -->\n')
+                xf.write('Entities: &amp;')
+        self.assertXml(
+            '<test>Comments: &lt;!-- text --&gt;\nEntities: &amp;amp;</test>')
+
     def test_encoding(self):
         with etree.xmlfile(self._file, encoding='utf16') as xf:
             with xf.element('test'):


### PR DESCRIPTION
- Accept Unicode strings for attribute values
- Do not erase the (element’s) 'tag' parameter when handling attributes
- Add some tests
