### PR TITLE
Incremental serializer: fix namespaces

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -781,9 +781,9 @@ cdef class _IncrementalFileWriter:
         if nsmap is not None and href in nsmap:
             return nsmap[href]
         for element_config in reversed(self._element_stack):
-            nsmap = element_config[-1]
-            if href in nsmap:
-                return nsmap[href]
+            ancestor_nsmap = element_config[-1]
+            if href in ancestor_nsmap:
+                return ancestor_nsmap[href]
         i = 0
         while 1:
             prefix = _utf8('ns%d' % i)

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -88,6 +88,13 @@ class _XmlFileTestCaseBase(HelperTestCase):
                 pass
         self.assertXml('<ns0:test xmlns:ns0="nsURI"></ns0:test>')
 
+    def test_namespace_nested_anonymous(self):
+        with etree.xmlfile(self._file) as xf:
+            with xf.element('test'):
+                with xf.element('{nsURI}toast'):
+                    pass
+        self.assertXml('<test><ns0:toast xmlns:ns0="nsURI"></ns0:toast></test>')
+
     def test_pi(self):
         with etree.xmlfile(self._file) as xf:
             xf.write(etree.ProcessingInstruction('pypi'))


### PR DESCRIPTION
- Reject invalid prefixes (only None, unicode or ASCII-only bytes are valid)
- Pick a prefix for namespaces without one
- Write prefix declarations with attributes.
