### PR TITLE
repair attribute mis-interpretation in ElementTreeContentHandler

### DIFF
--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -26,6 +26,12 @@ def _getNsTag(tag):
     else:
         return (None, tag)
 
+def _getAttrNSTag(attr_key):
+    if ":" in attr_key:
+        return tuple(attr_key.split(":", 1))
+    else:
+        return (None, attr_key)
+
 class ElementTreeContentHandler(ContentHandler):
     """Build an lxml ElementTree from SAX events.
     """
@@ -45,7 +51,7 @@ class ElementTreeContentHandler(ContentHandler):
         return ElementTree(self._root)
 
     etree = property(_get_etree, doc=_get_etree.__doc__)
-    
+
     def setDocumentLocator(self, locator):
         pass
 
@@ -127,6 +133,10 @@ class ElementTreeContentHandler(ContentHandler):
             raise SaxError("Unexpected element closed: " + el_tag)
 
     def startElement(self, name, attributes=None):
+        if attributes is not None:
+            attributes = dict(
+                    [(_getAttrNSTag(k), v) for k, v in attributes.items()]
+                )
         self.startElementNS((None, name), name, attributes)
 
     def endElement(self, name):
@@ -143,7 +153,7 @@ class ElementTreeContentHandler(ContentHandler):
             last_element.text = (last_element.text or '') + data
 
     ignorableWhitespace = characters
-        
+
 
 class ElementTreeProducer(object):
     """Produces SAX events for an element and children.

--- a/src/lxml/tests/test_sax.py
+++ b/src/lxml/tests/test_sax.py
@@ -216,6 +216,40 @@ class ETreeSaxTestCase(HelperTestCase):
         self.assertEqual('b', root[0].tag)
         self.assertEqual('c', root[1].tag)
 
+    def test_etree_sax_no_ns_attributes(self):
+        handler = sax.ElementTreeContentHandler()
+        handler.startDocument()
+        handler.startElement('a', {"attr_a1": "a1"})
+        handler.startElement('b', {"attr_b1": "b1"})
+        handler.endElement('b')
+        handler.endElement('a')
+        handler.endDocument()
+
+        new_tree = handler.etree
+        root = new_tree.getroot()
+        self.assertEqual('a', root.tag)
+        self.assertEqual('b', root[0].tag)
+        self.assertEqual('a1', root.attrib["attr_a1"])
+        self.assertEqual('b1', root[0].attrib["attr_b1"])
+
+    def test_etree_sax_ns_attributes(self):
+        handler = sax.ElementTreeContentHandler()
+        handler.startDocument()
+
+        handler.startElement('a', {"blaA:attr_a1": "a1"})
+        handler.startElement('b', {"blaA:attr_b1": "b1"})
+        handler.endElement('b')
+        handler.endElement('a')
+
+        handler.endDocument()
+
+        new_tree = handler.etree
+        root = new_tree.getroot()
+        self.assertEqual('a', root.tag)
+        self.assertEqual('b', root[0].tag)
+        self.assertEqual('a1', root.attrib["{blaA}attr_a1"])
+        self.assertEqual('b1', root[0].attrib["{blaA}attr_b1"])
+
     def test_etree_sax_error(self):
         handler = sax.ElementTreeContentHandler()
         handler.startDocument()
@@ -233,14 +267,14 @@ class ETreeSaxTestCase(HelperTestCase):
         handler = sax.ElementTreeContentHandler()
         sax.ElementTreeProducer(saxifiable, handler).saxify()
         return handler.etree
-        
+
     def _saxify_serialize(self, tree):
         new_tree = self._saxify_unsaxify(tree)
         f = BytesIO()
         new_tree.write(f)
         return f.getvalue().replace(_bytes('\n'), _bytes(''))
 
-    
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([unittest.makeSuite(ETreeSaxTestCase)])


### PR DESCRIPTION
regarding https://bugs.launchpad.net/lxml/+bug/1136509, this is a proposed fix for the issue.

The first part of the fix just rewrites the attributes in startElement to have keys of the form (namespace, key).  

At first, i set namespace to None, but I had a problem with that.  It appears that even namespaced attributes like the "xmlns:xsi" in my test document, is also passed to startElement, I suppose because the owning tag doesn't have a namespace.  So in this case I'm splitting on the colon and passing in the two tokens to startElementNS, but I'm not sure if this approach is correct.  In any case, I added two tests, if you can show what should happen in the tests at least that would make the correct behavior apparent here.
