### PR TITLE
repair non-namespace-aware attribute mis-interpretation in ElementTreeContentHandler

### DIFF
--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -26,11 +26,6 @@ def _getNsTag(tag):
     else:
         return (None, tag)
 
-def _getAttrNSTag(attr_key):
-    if ":" in attr_key:
-        return tuple(attr_key.split(":", 1))
-    else:
-        return (None, attr_key)
 
 class ElementTreeContentHandler(ContentHandler):
     """Build an lxml ElementTree from SAX events.
@@ -133,9 +128,9 @@ class ElementTreeContentHandler(ContentHandler):
             raise SaxError("Unexpected element closed: " + el_tag)
 
     def startElement(self, name, attributes=None):
-        if attributes is not None:
+        if attributes:
             attributes = dict(
-                    [(_getAttrNSTag(k), v) for k, v in attributes.items()]
+                    [((None, k), v) for k, v in attributes.items()]
                 )
         self.startElementNS((None, name), name, attributes)
 

--- a/src/lxml/tests/test_sax.py
+++ b/src/lxml/tests/test_sax.py
@@ -236,19 +236,10 @@ class ETreeSaxTestCase(HelperTestCase):
         handler = sax.ElementTreeContentHandler()
         handler.startDocument()
 
-        handler.startElement('a', {"blaA:attr_a1": "a1"})
-        handler.startElement('b', {"blaA:attr_b1": "b1"})
-        handler.endElement('b')
-        handler.endElement('a')
-
-        handler.endDocument()
-
-        new_tree = handler.etree
-        root = new_tree.getroot()
-        self.assertEqual('a', root.tag)
-        self.assertEqual('b', root[0].tag)
-        self.assertEqual('a1', root.attrib["{blaA}attr_a1"])
-        self.assertEqual('b1', root[0].attrib["{blaA}attr_b1"])
+        self.assertRaises(ValueError,
+            handler.startElement,
+            'a', {"blaA:attr_a1": "a1"}
+        )
 
     def test_etree_sax_error(self):
         handler = sax.ElementTreeContentHandler()


### PR DESCRIPTION
this pull request allows the usage of non-NS aware SAX parsers to work properly with ElementTreeContentHandler, regarding attributes.   This refers to https://bugs.launchpad.net/lxml/+bug/1136509.

Summary test:

```
document = """<?xml version="1.0" encoding="utf-8"?>
<SomeDocument>
    <Data FooBar="123">
    </Data>
</SomeDocument>
"""

from lxml import sax
from xml.sax import parse
from StringIO import StringIO

parse(StringIO(document), sax.ElementTreeContentHandler())
```

Above, the non-namespace aware parser generated by xml.sax.parse() calls the startElement() method, which ElementTreeContentHandler refers to startElementNS().  The attribute "FooBar" however must be expanded to the form `(None, "FooBar"): "123"` in order to be interpreted correctly by startElementNS().
