### PR TITLE
Fix typo in path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build
 libs
 *.egg-info
 *.so
-src/lxml/include/lxml-version.h
+src/lxml/includes/lxml-version.h
 src/lxml/lxml.etree.c
 src/lxml/lxml.etree.h
 src/lxml/lxml.etree_api.h


### PR DESCRIPTION
After building from source `git status` shows `src/lxml/includes/lxml-version.h` as untracked. I guess that is because in `.gitignore` the path is misspelled.
