### PR TITLE
Fix LP:#1074996

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -915,7 +915,9 @@ def open_http_urllib(method, url, values):
         url += urlencode(values)
         data = None
     else:
-        data = urlencode(values)
+    ## FIXME: Find a way to ask user about preferred encoding scheme and use it.
+    ## encoding to bytes is REQUIRED in python3.
+        data = urlencode(values).encode('utf-8')
     return urlopen(url, data)
 
 class FieldsDict(DictMixin):


### PR DESCRIPTION
In python3, urlopen expects a byte stream for the POST data. this patch encodes the data in utf-8 before transmission. Essentially a hack, since a proper fix involves allowing the user to specify an encoding scheme of choice.
