### PR TITLE
lxml.html.formfill: Fix textarea form filling.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,11 @@ Bugs fixed
 
 * Compressed plain-text serialisation to file-like objects was broken.
 
+* lxml.html.formfill: Fix textarea form filling.
+  The textarea used to be cleared before the new content was set,
+  which removed the name attribute.
+
+
 Other changes
 -------------
 

--- a/src/lxml/html/formfill.py
+++ b/src/lxml/html/formfill.py
@@ -127,7 +127,6 @@ def _select(el, select):
 
 def _fill_single(input, value):
     if _nons(input.tag) == 'textarea':
-        input.clear()
         input.text = value
     else:
         input.set('value', value)

--- a/src/lxml/html/tests/test_formfill.txt
+++ b/src/lxml/html/tests/test_formfill.txt
@@ -98,3 +98,15 @@ Example::
       <input name="v4" class="error">
       <input name="v4">
     </form>
+
+
+REGRESSION: When filling textareas, the "name" attribute used to
+be removed. The "name" attribute should be kept::
+
+    >>> print(fill_form_html('''
+    ... <form>
+    ...   <textarea name="foo">Initial value</textarea>
+    ... </form>''', dict(foo="Bar")))
+    <form>
+      <textarea name="foo">Bar</textarea>
+    </form>


### PR DESCRIPTION
**Problem**
When a textarea is filled using `lxml.html.formfill`, the `name` attribute (and all other attributes) are removed because `input.clear()` is called before the textarea is filled.

**Effect**
The textarea field is no longer usable and the field and its value does not show up when submitting the form (e.g. with `lxml.html.submit_form`).

**Cause**
The `input.clear()` resets the element and removes all attributes, as described in the docstring:

```
input.clear():
Resets an element.  This function removes all subelements, clears
all attributes and sets the text and tail properties to None.
```

**Fix**
I've removed the `input.clear()`. I'm not sure why it was there in the first place and couldn't find out.
I've added a regression test.
