### PR TITLE
use correct array bound when accessing c_namespaces

### DIFF
--- a/src/lxml/saxparser.pxi
+++ b/src/lxml/saxparser.pxi
@@ -322,7 +322,7 @@ cdef void _handleSaxTargetStart(
             nsmap = EMPTY_READ_ONLY_DICT
         else:
             nsmap = {}
-            for i in xrange(c_nb_attributes):
+            for i in xrange(c_nb_namespaces):
                 prefix = funicodeOrNone(c_namespaces[0])
                 nsmap[prefix] = funicode(c_namespaces[1])
                 c_namespaces += 2


### PR DESCRIPTION
When iterating through c_namespaces in <b>_handleSaxTargetStart()</b>, the code used incorrect array bound. It should use c_nb_namespaces, but it used c_nb_attributes.
This caused segmentation fault when c_nb_attributes > c_nb_namespaces.

Test case attached. This case segfault at latest version. Sometimes it throws UnicodeDecodeError instead, because the out-of-bound access luckily hit some data.

``` python
from lxml import etree

s = "<presence><c xmlns='http://jabber.org/protocol/caps' node='http://pidgin.im/' hash='sha-1' ver='lV6i//bt2U8Rm0REcX8h4F3Nk3M=' ext='voice-v1 camera-v1 video-v1'/></presence>"

class EchoTarget(object):
    def start(self, tag, attrib):
        print("start %s %r" % (tag, dict(attrib)))
    def end(self, tag):
        print("end %s" % tag)
    def data(self, data):
        print("data %r" % data)
    def comment(self, text):
        print("comment %s" % text)
    def close(self):
        print("close")
        return "closed!"

parser = etree.XMLParser(target = EchoTarget())
parser.feed(s)
result = parser.close()
print(result)
```
