### PR TITLE
Disable resolve_entities by default w/ one billion laughs expansion bug.

### DIFF
--- a/doc/resolvers.txt
+++ b/doc/resolvers.txt
@@ -83,7 +83,7 @@ Resolvers are registered local to a parser:
 
 .. sourcecode:: pycon
 
-  >>> parser = etree.XMLParser(load_dtd=True)
+  >>> parser = etree.XMLParser(load_dtd=True, resolve_entities=True)
   >>> parser.resolvers.add( DTDResolver() )
 
 Note that we instantiate a parser that loads the DTD.  This is not done by the

--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -710,13 +710,14 @@ general document handling.
 
 .. sourcecode:: pycon
 
+    >>> parser = etree.XMLParser(resolve_entities=True)
     >>> root = etree.XML('''\
     ... <?xml version="1.0"?>
     ... <!DOCTYPE root SYSTEM "test" [ <!ENTITY tasty "parsnips"> ]>
     ... <root>
     ...   <a>&tasty;</a>
     ... </root>
-    ... ''')
+    ... ''', parser=parser)
 
     >>> tree = etree.ElementTree(root)
     >>> print(tree.docinfo.xml_version)

--- a/src/lxml/iterparse.pxi
+++ b/src/lxml/iterparse.pxi
@@ -43,7 +43,7 @@ cdef class iterparse:
      - remove_pis: discard processing instructions
      - strip_cdata: replace CDATA sections by normal text content (default: True)
      - compact: safe memory for short text content (default: True)
-     - resolve_entities: replace entities by their text value (default: True)
+     - resolve_entities: replace entities by their text value (default: False)
      - huge_tree: disable security restrictions and support very deep trees
                   and very long text content (only affects libxml2 2.7+)
      - html: parse input as HTML (default: XML)
@@ -66,7 +66,7 @@ cdef class iterparse:
     def __init__(self, source, events=(u"end",), *, tag=None,
                  attribute_defaults=False, dtd_validation=False,
                  load_dtd=False, no_network=True, remove_blank_text=False,
-                 compact=True, resolve_entities=True, remove_comments=False,
+                 compact=True, resolve_entities=False, remove_comments=False,
                  remove_pis=False, strip_cdata=True, encoding=None,
                  html=False, recover=None, huge_tree=False,
                  XMLSchema schema=None):

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1301,7 +1301,7 @@ _XML_DEFAULT_PARSE_OPTIONS = (
     )
 
 cdef class XMLParser(_FeedParser):
-    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, XMLSchema schema=None, remove_blank_text=False, resolve_entities=True, remove_comments=False, remove_pis=False, strip_cdata=True, target=None, compact=True)
+    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, XMLSchema schema=None, remove_blank_text=False, resolve_entities=False, remove_comments=False, remove_pis=False, strip_cdata=True, target=None, compact=True)
 
     The XML parser.
 
@@ -1330,7 +1330,7 @@ cdef class XMLParser(_FeedParser):
     - remove_pis         - discard processing instructions
     - strip_cdata        - replace CDATA sections by normal text content (default: True)
     - compact            - safe memory for short text content (default: True)
-    - resolve_entities   - replace entities by their text value (default: True)
+    - resolve_entities   - replace entities by their text value (default: False)
     - huge_tree          - disable security restrictions and support very deep trees
                            and very long text content (only affects libxml2 2.7+)
 
@@ -1347,7 +1347,7 @@ cdef class XMLParser(_FeedParser):
     def __init__(self, *, encoding=None, attribute_defaults=False,
                  dtd_validation=False, load_dtd=False, no_network=True,
                  ns_clean=False, recover=False, XMLSchema schema=None,
-                 huge_tree=False, remove_blank_text=False, resolve_entities=True,
+                 huge_tree=False, remove_blank_text=False, resolve_entities=False,
                  remove_comments=False, remove_pis=False, strip_cdata=True,
                  target=None, compact=True):
         cdef int parse_options
@@ -1416,7 +1416,7 @@ cdef class ETCompatXMLParser(XMLParser):
     u"""ETCompatXMLParser(self, encoding=None, attribute_defaults=False, \
                  dtd_validation=False, load_dtd=False, no_network=True, \
                  ns_clean=False, recover=False, schema=None, \
-                 huge_tree=False, remove_blank_text=False, resolve_entities=True, \
+                 huge_tree=False, remove_blank_text=False, resolve_entities=False, \
                  remove_comments=True, remove_pis=True, strip_cdata=True, \
                  target=None, compact=True)
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1141,7 +1141,7 @@ class ETreeOnlyTestCase(HelperTestCase):
 
     def test_resolve_string_dtd(self):
         parse = self.etree.parse
-        parser = self.etree.XMLParser(dtd_validation=True)
+        parser = self.etree.XMLParser(dtd_validation=True, resolve_entities=True)
         assertEqual = self.assertEqual
         test_url = _str("__nosuch.dtd")
 
@@ -1161,7 +1161,7 @@ class ETreeOnlyTestCase(HelperTestCase):
 
     def test_resolve_bytes_dtd(self):
         parse = self.etree.parse
-        parser = self.etree.XMLParser(dtd_validation=True)
+        parser = self.etree.XMLParser(dtd_validation=True, resolve_entities=True)
         assertEqual = self.assertEqual
         test_url = _str("__nosuch.dtd")
 
@@ -1182,7 +1182,7 @@ class ETreeOnlyTestCase(HelperTestCase):
 
     def test_resolve_filelike_dtd(self):
         parse = self.etree.parse
-        parser = self.etree.XMLParser(dtd_validation=True)
+        parser = self.etree.XMLParser(dtd_validation=True, resolve_entities=True)
         assertEqual = self.assertEqual
         test_url = _str("__nosuch.dtd")
 
@@ -1270,7 +1270,7 @@ class ETreeOnlyTestCase(HelperTestCase):
 
     def test_resolve_empty(self):
         parse = self.etree.parse
-        parser = self.etree.XMLParser(load_dtd=True)
+        parser = self.etree.XMLParser(load_dtd=True, resolve_entities=True)
         assertEqual = self.assertEqual
         test_url = _str("__nosuch.dtd")
 
@@ -1341,6 +1341,15 @@ class ETreeOnlyTestCase(HelperTestCase):
                               ['child3', 'child2'])
             self.assertEqual(root[0][0].text, '&nbsp;')
             self.assertEqual(root[0][0].name, 'nbsp')
+
+        def test_entity_parse_entity_default(self):
+            parse = self.etree.parse
+            parser = self.etree.XMLParser()
+
+            xml = _bytes("<!DOCTYPE foo [ <!ENTITY bar SYSTEM 'file:///etc/passwd'>]><foo>&bar;</foo>")
+            tree = parse(BytesIO(xml), parser)
+            root = tree.getroot()
+            self.assertEqual(root.text, None)
 
     def test_entity_append(self):
         Entity = self.etree.Entity

--- a/src/lxml/tests/test_http_io.py
+++ b/src/lxml/tests/test_http_io.py
@@ -102,7 +102,7 @@ class HttpIOTestCase(HelperTestCase):
             tree = self.etree.parse(
                 host_url + 'dir/test.xml',
                 parser=self.etree.XMLParser(
-                    load_dtd=True, no_network=False))
+                    load_dtd=True, no_network=False, resolve_entities=True))
             self.assertFalse(responses)  # all read
             root = tree.getroot()
             self.assertEqual('DEFINED', root.text)
@@ -113,7 +113,7 @@ class HttpIOTestCase(HelperTestCase):
                 self.etree.parse(
                     host_url + 'dir/test.xml',
                     parser=self.etree.XMLParser(
-                        load_dtd=True, no_network=True))
+                        load_dtd=True, no_network=True, resolve_entities=True))
             except self.etree.XMLSyntaxError:
                 self.assertTrue("myentity" in str(sys.exc_info()[1]))
             else:


### PR DESCRIPTION
Facebook recently issued its largest bug bounty to remove this security bug.

https://www.facebook.com/BugBounty/posts/778897822124446?stream_ref=10

This may result in breaking changes but should be considered an important
security enhancement.

Test fix included.
