### PR TITLE
include links in meta refresh tags in iterlinks

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -381,6 +381,20 @@ class HtmlMixin(object):
         for el in self.iter(etree.Element):
             attribs = el.attrib
             tag = _nons(el.tag)
+            if tag == 'meta':
+                http_equiv = attribs.get('http-equiv', '').lower()
+                if http_equiv == 'refresh':
+                    content = attribs.get('content', '')
+                    i = content.find(';')
+                    url = content[i+1:] if i > -1 else content
+                    if 'url=' == url[:4].lower():
+                        url = url[4:]
+                    #else:
+                        # No "url=" means the redirect won't work, but we might
+                        # as well be permissive and return the entire string.
+                    if url:
+                        url, pos = _unquote_match(url, i + 5)
+                        yield (el, 'content', url, pos)
             if tag != 'object':
                 for attrib in link_attrs:
                     if attrib in attribs:

--- a/src/lxml/html/tests/test_rewritelinks.txt
+++ b/src/lxml/html/tests/test_rewritelinks.txt
@@ -101,6 +101,8 @@ link)``, which is awkward to test here, so we'll make a printer::
     >>> print_iter(iterlinks('''
     ... <html>
     ...  <head>
+    ...   <meta http-equiv="refresh" content="0;url=/redirect">
+    ...   <meta http-equiv="refresh" content="10;url='/quoted_url'">
     ...   <link rel="stylesheet" href="style.css">
     ...   <style type="text/css">
     ...     body {
@@ -119,9 +121,13 @@ link)``, which is awkward to test here, so we'll make a printer::
     ...    <td style="background-image: url(/td-bg.png)">
     ...      <img src="/logo.gif">
     ...      Hi world!
+    ...    </td>
+    ...    <td style="background-image: url('/quoted.png')">
     ...    </td></tr>
     ...   </table>
     ...  </body></html>'''))
+    meta content="/redirect"@6
+    meta content="/quoted_url"@8
     link href="style.css"
     style None="/other-styles.css"@69
     style None="/bg.gif"@40
@@ -130,6 +136,7 @@ link)``, which is awkward to test here, so we'll make a printer::
     a href="/other.html"
     td style="/td-bg.png"@22
     img src="/logo.gif"
+    td style="/quoted.png"@23
 
 An application of ``iterlinks()`` is ``make_links_absolute()``::
 


### PR DESCRIPTION
This patch allows lxml.html's `iterlinks` function to find links inside `<meta http-equiv="refresh"...>` tags.

Includes a passing test case. Run with "python -m doctest test_rewritelinks.txt" from the "lxml/html/tests" directory.

Thanks in advance for reviewing!
