### PR TITLE
lxml.html.document_fromstring ensure_head option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ Latest changes
 Features added
 --------------
 
+* ``lxml.html.document_fromstring`` now accepts an ``ensure_head_body`` option.
+  If true, the resulting document will be given an empty head if it didn't
+  have one originally and an empty body if it didn't have one originally.
+  Default: false.
+
 * ``lxml.html.iterlinks`` now returns links inside meta refresh tags.
 
 * New ``XMLParser`` option ``collect_ids=False`` to disable ID hash table

--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -607,13 +607,17 @@ _looks_like_full_html_unicode = re.compile(
 _looks_like_full_html_bytes = re.compile(
     r'^\s*<(?:html|!doctype)'.encode('ascii'), re.I).match
 
-def document_fromstring(html, parser=None, **kw):
+def document_fromstring(html, parser=None, ensure_head_body=False, **kw):
     if parser is None:
         parser = html_parser
     value = etree.fromstring(html, parser, **kw)
     if value is None:
         raise etree.ParserError(
             "Document is empty")
+    if ensure_head_body and value.find('head') is None:
+        value.insert(0, Element('head'))
+    if ensure_head_body and value.find('body') is None:
+        value.append(Element('body'))
     return value
 
 def fragments_fromstring(html, no_leading_text=False, base_url=None,

--- a/src/lxml/html/tests/test_basic.txt
+++ b/src/lxml/html/tests/test_basic.txt
@@ -160,3 +160,20 @@ Bug 690319: Leading whitespace before doctype declaration should not raise an er
     >>> print(tostring(etree_document, encoding=unicode))
     <html></html>
 
+Feature https://github.com/lxml/lxml/pull/140: ensure_head_body option:
+
+    >>> from lxml.html import document_fromstring, tostring
+    >>> from functools import partial
+    >>> tos = partial(tostring, encoding=unicode)
+    >>> print(tos(document_fromstring('<p>test</p>')))
+    <html><body><p>test</p></body></html>
+    >>> print(tos(document_fromstring('<p>test</p>', ensure_head_body=True)))
+    <html><head></head><body><p>test</p></body></html>
+    >>> print(tos(document_fromstring('<meta>')))
+    <html><head><meta></head></html>
+    >>> print(tos(document_fromstring('<meta>', ensure_head_body=True)))
+    <html><head><meta></head><body></body></html>
+    >>> print(tos(document_fromstring('<html></html>')))
+    <html></html>
+    >>> print(tos(document_fromstring('<html></html>', ensure_head_body=True)))
+    <html><head></head><body></body></html>


### PR DESCRIPTION
When using lxml.html.document_fromstring to process html outside your control,
you can't be sure it will have a head element. Allowing document_fromstring to
accept an ensure_head option saves you from having to write code like:

```
doc = document_fromstring(html)
try:
    doc.head
except IndexError:
    from lxml.html import builder
    doc.insert(0, builder.HEAD())
# now we can safely reference doc.head
```

and instead just write:

```
doc = document_fromstring(html, ensure_head=True)
```
