### PR TITLE
minor, str.join() expects strings

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -39,7 +39,7 @@ def env_var(name):
         return []
 
 def ext_modules(static_include_dirs, static_library_dirs,
-                static_cflags, static_binaries): 
+                static_cflags, static_binaries):
     global XML2_CONFIG, XSLT_CONFIG
     if OPTION_BUILD_LIBXML2XSLT:
         from buildlibxml import build_libxml2xslt, get_prebuilt_libxml2xslt
@@ -90,11 +90,11 @@ def ext_modules(static_include_dirs, static_library_dirs,
     lib_versions = get_library_versions()
     versions_ok = True
     if lib_versions[0]:
-        print("Using build configuration of libxml2 %s and libxslt %s" % 
+        print("Using build configuration of libxml2 %s and libxslt %s" %
               lib_versions)
         versions_ok = check_min_version(lib_versions[0], (2, 7, 0), 'libxml2')
     else:
-        print("Using build configuration of libxslt %s" % 
+        print("Using build configuration of libxslt %s" %
               lib_versions[1])
     versions_ok |= check_min_version(lib_versions[1], (1, 1, 23), 'libxslt')
     if not versions_ok:
@@ -298,7 +298,7 @@ def check_min_version(version, min_version, error_name):
     min_version = tuple(min_version)
     if version < min_version:
         print("Minimum required version of %s is %s, found %s" % (
-            error_name, '.'.join(version), '.'.join(min_version)))
+            error_name, '.'.join(map(str, version)), '.'.join(map(str, min_version))))
         return False
     return True
 


### PR DESCRIPTION
With versions below minimum version, instead of raising
an informative error message the following traceback occurs:
TypeError: sequence item 0: expected string, int found

``` python
>>> git checkout upstream/master
>>> python -c "import setupinfo; print(setupinfo.check_min_version('1.1.17', (1, 1, 23), 'libxslt'))"
  Traceback (most recent call last):
  File "<string>", line 1, in ?
  File "setupinfo.py", line 300, in check_min_version
    print("Minimum required version of %s is %s, found %s" % (
TypeError: sequence item 0: expected string, int found
>>> git checkout master
>>> python -c "import setupinfo; print(setupinfo.check_min_version('1.1.17', (1, 1, 23), 'libxslt'))"
Minimum required version of libxslt is 1.1.17, found 1.1.23
False
```

Change-Id: I5ac35935cd61786181e1c6372e752a1600cc2c2d
