### PR TITLE
'too many bodies' should not include 0

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -646,7 +646,7 @@ def fragments_fromstring(html, no_leading_text=False, base_url=None,
     doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
     assert _nons(doc.tag) == 'html'
     bodies = [e for e in doc if _nons(e.tag) == 'body']
-    assert len(bodies) < 2, ("too many bodies: %r in %r" % (bodies, html))
+    assert len(bodies) == 1, ("should be one body element: %r in %r" % (bodies, html))
     body = bodies[0]
     elements = []
     if no_leading_text and body.text and body.text.strip():

--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -646,7 +646,7 @@ def fragments_fromstring(html, no_leading_text=False, base_url=None,
     doc = document_fromstring(html, parser=parser, base_url=base_url, **kw)
     assert _nons(doc.tag) == 'html'
     bodies = [e for e in doc if _nons(e.tag) == 'body']
-    assert len(bodies) == 1, ("too many bodies: %r in %r" % (bodies, html))
+    assert len(bodies) < 2, ("too many bodies: %r in %r" % (bodies, html))
     body = bodies[0]
     elements = []
     if no_leading_text and body.text and body.text.strip():


### PR DESCRIPTION
changed check for number of bodies to < 2, as the error 'too many bodies' can currently be thrown when len(bodies) == 0
