### PR TITLE
Do not filter out inline data in images

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -71,7 +71,7 @@ _css_import_re = re.compile(
 # All kinds of schemes besides just javascript: that can cause
 # execution:
 _is_javascript_scheme = re.compile(
-    r'(?:javascript|jscript|livescript|vbscript|data|about|mocha):',
+    r'(?:javascript|jscript|livescript|vbscript|about|mocha):',
     re.I).search
 _substitute_whitespace = re.compile(r'[\s\x00-\x08\x0B\x0C\x0E-\x19]+').sub
 # FIXME: should data: be blocked?


### PR DESCRIPTION
Image inline data is not necessarily Javascript so data: attribute should not be stripped out