### PR TITLE
CDATA support in _setTailText

### DIFF
--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -703,8 +703,18 @@ cdef int _setTailText(xmlNode* c_node, value) except -1:
     _removeText(c_node.next)
     if value is None:
         return 0
-    text = _utf8(value)
-    c_text_node = tree.xmlNewDocText(c_node.doc, _xcstr(text))
+    if python._isString(value):
+        text = _utf8(value)
+        c_text_node = tree.xmlNewDocText(c_node.doc, _xcstr(text))
+    elif isinstance(value, CDATA):
+        c_text_node = tree.xmlNewCDataBlock(
+            c_node.doc, _xcstr((<CDATA>value)._utf8_data),
+            python.PyBytes_GET_SIZE((<CDATA>value)._utf8_data))
+    else:
+        # this will raise the right error
+        _utf8(value)
+        return -1
+
     # XXX what if we're the top element?
     tree.xmlAddNextSibling(c_node, c_text_node)
     return 0


### PR DESCRIPTION
Current version of `lxml` does not support wrapping `_Element.tail` to `CDATA`.

``` python
>>> from lxml import etree
>>> etree.__version__
u'3.4.1'
>>> a = '<a>left<h>in</h>right</a>'
>>> xml = etree.fromstring(a)
>>> h = xml.find('h')
>>> h.tail
'right'
>>> h.text
'in'
>>> h.text = etree.CDATA(h.text)
>>> h.tail = etree.CDATA(h.tail)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lxml.etree.pyx", line 959, in lxml.etree._Element.tail.__set__ (src/lxml/lxml.etree.c:46540)
  File "apihelpers.pxi", line 706, in lxml.etree._setTailText (src/lxml/lxml.etree.c:21071)
  File "apihelpers.pxi", line 1391, in lxml.etree._utf8 (src/lxml/lxml.etree.c:27146)
TypeError: Argument must be bytes or unicode, got 'CDATA'
```
