### PR TITLE
Make lxml.doctestcompare consistent with stdlib's doctest

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,10 @@ Bugs fixed
 
 * CDATA sections were not serialised as tail text of the top-level element.
 
+* lxml.doctestcompare is now consistent with stdlib's doctest in how it
+  uses ``+`` and ``-`` to refer to unexpected and missing output
+  (LP: #1238503).
+
 
 3.4.1 (2014-11-20)
 ==================

--- a/src/lxml/doctestcompare.py
+++ b/src/lxml/doctestcompare.py
@@ -29,8 +29,8 @@ attribute matches any and all attributes.
 
 When a match fails, the reformatted example and gotten text is
 displayed (indented), and a rough diff-like output is given.  Anything
-marked with ``-`` is in the output but wasn't supposed to be, and
-similarly ``+`` means its in the example but wasn't in the output.
+marked with ``+`` is in the output but wasn't supposed to be, and
+similarly ``-`` means its in the example but wasn't in the output.
 
 You can disable parsing on one line with ``# doctest:+NOPARSE_MARKUP``
 """
@@ -306,10 +306,10 @@ class LXMLOutputChecker(OutputChecker):
         got_children = list(got)
         while want_children or got_children:
             if not want_children:
-                parts.append(self.format_doc(got_children.pop(0), html, indent+2, '-'))
+                parts.append(self.format_doc(got_children.pop(0), html, indent+2, '+'))
                 continue
             if not got_children:
-                parts.append(self.format_doc(want_children.pop(0), html, indent+2, '+'))
+                parts.append(self.format_doc(want_children.pop(0), html, indent+2, '-'))
                 continue
             parts.append(self.collect_diff(
                 want_children.pop(0), got_children.pop(0), html, indent+2))
@@ -331,7 +331,7 @@ class LXMLOutputChecker(OutputChecker):
         any = want.tag == 'any' or 'any' in want.attrib
         for name, value in sorted(got.attrib.items()):
             if name not in want.attrib and not any:
-                attrs.append('-%s="%s"' % (name, self.format_text(value, False)))
+                attrs.append('+%s="%s"' % (name, self.format_text(value, False)))
             else:
                 if name in want.attrib:
                     text = self.collect_diff_text(want.attrib[name], value, False)
@@ -342,7 +342,7 @@ class LXMLOutputChecker(OutputChecker):
             for name, value in sorted(want.attrib.items()):
                 if name in got.attrib:
                     continue
-                attrs.append('+%s="%s"' % (name, self.format_text(value, False)))
+                attrs.append('-%s="%s"' % (name, self.format_text(value, False)))
         if attrs:
             tag = '<%s %s>' % (tag, ' '.join(attrs))
         else:

--- a/src/lxml/tests/test_doctestcompare.py
+++ b/src/lxml/tests/test_doctestcompare.py
@@ -83,6 +83,43 @@ class DoctestCompareTest(HelperTestCase):
             '<p title="actual">Actual</p>',
             '<p title="expected (got: actual)">Expected (got: Actual)</p>\n')
 
+    def test_extra_children(self):
+        # https://bugs.launchpad.net/lxml/+bug/1238503
+        self.assert_diff(
+            '<p><span>One</span></p>',
+            '<p><span>One</span><b>Two</b><em>Three</em></p>',
+            '<p>\n'
+            '  <span>One</span>\n'
+            '  +<b>Two</b>\n'
+            '  +<em>Three</em>\n'
+            '</p>\n')
+
+    def test_missing_children(self):
+        self.assert_diff(
+            '<p><span>One</span><b>Two</b><em>Three</em></p>',
+            '<p><span>One</span></p>',
+            '<p>\n'
+            '  <span>One</span>\n'
+            '  -<b>Two</b>\n'
+            '  -<em>Three</em>\n'
+            '</p>\n')
+
+    def test_extra_attributes(self):
+        self.assert_diff(
+            '<p><span class="foo">Text</span></p>',
+            '<p><span class="foo" id="bar">Text</span></p>',
+            '<p>\n'
+            '  <span class="foo" +id="bar">Text</span>\n'
+            '</p>\n')
+
+    def test_missing_attributes(self):
+        self.assert_diff(
+            '<p><span class="foo" id="bar">Text</span></p>',
+            '<p><span class="foo">Text</span></p>',
+            '<p>\n'
+            '  <span class="foo" -id="bar">Text</span>\n'
+            '</p>\n')
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/lxml/+bug/1238503
