### PR TITLE
Fix CFLAGS in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@
 envlist = py26, py27, py32, py33, py34
 
 [testenv]
-setenv = CFLAGS="-g -O0"
+setenv =
+    CFLAGS = -g -O0
 commands =
     {envpython} setup.py clean
     {envpython} setup.py build_ext --inplace


### PR DESCRIPTION
Without this fix gcc 4.9 (the default C compiler on Ubuntu 14.10) aborts with
the following error:

```
cc1: error: unrecognised debug output level " -O0"
```

As far as I can tell this happens because "-g -O0" is passed as a single 
argv[] entry to the C compiler.

The 'setenv' parameter in tox.ini is not shell code, it doesn't need to be
quoted (and spaces around '=' are also okay[*], so I added them, to make it
apparent this is not shell syntax).

[*] http://tox.readthedocs.org/en/latest/example/basic.html#setting-environment-variables
