### PR TITLE
Retry pip install a few times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - pypy3
 
 install:
-    pip install --use-mirrors -r requirements.txt
+    travis_retry pip install -r requirements.txt
 
 script:
   - python -u setup.py clean


### PR DESCRIPTION
There's a race condition in Cython's setup script that makes
'pip install Cython' fail once in a blue moon: 
https://groups.google.com/forum/#!msg/cython-users/bKYut7C9t7k/15MKCquPZLEJ

Retrying should make it succeed and avoid false failures on pull requests.

(I also dropped the deprecated --use-mirrors option of pip install.)
