### PR TITLE
Remove pre-2.6 compatibility imports/aliases

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -37,9 +37,9 @@ import re
 
 from collections import MutableMapping
 
-from lxml import etree
-from lxml.html import defs
-from lxml.html._setmixin import SetMixin
+from .. import etree
+from . import defs
+from ._setmixin import SetMixin
 
 try:
     from urlparse import urljoin


### PR DESCRIPTION
also
- remove aliasing of `MutableMapping` to `DictMixin`
- remove duplicate `sys` import
- ~~move conditional urlopen and urlencode to top~~
- shuffle imports around to try and better match pep8

there's a few imports left in the module body (`os`, `tempfile`, `webbrowser` imported in `open_in_browser`), not sure I should fix them.

Also I _think_ `__fix_docstring` could be altered to only munge the byte and unicode literals for versions of Python between 3.0 and 3.2 inclusive (since 2.6+ has byte literals, and 3.3 reintroduced unicode literals)
