### PR TITLE
Provide a set interface to HTML classes

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -124,7 +124,58 @@ def _nons(tag):
             return tag.split('}')[-1]
     return tag
 
+class Classes(SetMixin):
+    """ Provides access to the element's classes as a standard set.
+
+    Has an additional ``toggle`` method matching ``DOMTokenList.toggle``'s
+    semantics
+    """
+    def __init__(self, instance):
+        self._instance = instance
+
+    def __iter__(self):
+        classes = self._instance.get('class')
+        if not classes:
+            return iter(())
+        return iter(classes.split(' '))
+
+    def add(self, item):
+        if re.search('\s', item):
+            raise ValueError("Classes can not contain whitespace")
+        if item in self:
+            return
+        classes = self._instance.get('class', '').split()
+        classes.append(item)
+        self._instance.set('class', ' '.join(classes))
+
+    def remove(self, item):
+        if re.search('\s', item):
+            raise ValueError("Classes can not contain whitespace")
+        if item not in self:
+            raise KeyError(item)
+
+        classes = ' '.join(cls for cls in self if cls != item)
+        if classes:
+            self._instance.set('class', classes)
+        else:
+            del self._instance.attrib['class']
+
+    def toggle(self, item, force=None):
+        if re.search('\s', item):
+            raise ValueError("Classes can not contain whitespace")
+        if item in self:
+            if force is True:
+                return True
+            self.discard(item)
+            return False
+        else:
+            if force is False:
+                return False
+            self.add(item)
+            return True
+
 class HtmlMixin(object):
+    classes = property(Classes)
 
     def base_url(self):
         """

--- a/src/lxml/html/tests/test_basic.txt
+++ b/src/lxml/html/tests/test_basic.txt
@@ -41,8 +41,8 @@ as well as the ability to toggle classes using a set-like interface
    ['bar', 'foo', 'quux', 'qux']
    >>> el.classes.clear()
    >>> el.get('class')
-   >>> set(el.classes)
-   set([])
+   >>> list(el.classes)
+   []
    >>> el.classes.add('a')
    >>> el.classes.add('b')
    >>> el.classes.remove('a')

--- a/src/lxml/html/tests/test_basic.txt
+++ b/src/lxml/html/tests/test_basic.txt
@@ -29,6 +29,60 @@ lxml.html adds a find_class method to elements::
     >>> print([e.text for e in h.find_class('vcard')])
     ['P1', 'P2']
 
+as well as the ability to toggle classes using a set-like interface
+
+   >>> el = fragment_fromstring('<span class="foo bar"></span>')
+   >>> 'foo' in el.classes
+   True
+   >>> 'f00' in el.classes
+   False
+   >>> el.classes.update(('qux', 'quux'))
+   >>> sorted(el.get('class').split())
+   ['bar', 'foo', 'quux', 'qux']
+   >>> el.classes.clear()
+   >>> el.get('class')
+   >>> set(el.classes)
+   set([])
+   >>> el.classes.add('a')
+   >>> el.classes.add('b')
+   >>> el.classes.remove('a')
+   >>> el.classes.remove('c')
+   Traceback (most recent call last):
+       ...
+   KeyError: 'c'
+   >>> el.classes.discard('c')
+   >>> el.get('class')
+   'b'
+   >>> el.classes.add('b')
+   >>> el.get('class')
+   'b'
+
+with an extra toggle method matching DOMTokenList
+
+   >>> el.classes.toggle('b')
+   False
+   >>> el.get('class')
+   >>> el.classes.toggle('foo', False)
+   False
+   >>> el.get('class')
+   >>> el.classes.toggle('foo', True)
+   True
+   >>> el.classes.toggle('foo', True)
+   True
+   >>> el.get('class')
+   'foo'
+   >>> el.classes.toggle('foo')
+   False
+   >>> el.get('class')
+   >>> el.classes.add("foo\n")
+   Traceback (most recent call last):
+       ...
+   ValueError: Classes can not contain whitespace
+   >>> el.classes.remove("foo ")
+   Traceback (most recent call last):
+       ...
+   ValueError: Classes can not contain whitespace
+
 Also added is a get_rel_links, which you can use to search for links
 like ``<a rel="$something">``::
 


### PR DESCRIPTION
PR for https://bugs.launchpad.net/lxml/+bug/1243600

The assertions at the start of add/remove/toggle are to match DOMTokenList's behavior, they seem to make sense.

The set is a simple proxy to the underlying attribute's string (and remove the attribute entirely if the set is emptied to match "unset") which is simple enough for a first version but may not be the most efficient implementation for repeated set operations (should be good for a one-shot though).