### PR TITLE
Simplify SetMixin by rebuilding it on top of MutableSet

### DIFF
--- a/src/lxml/html/_setmixin.py
+++ b/src/lxml/html/_setmixin.py
@@ -1,4 +1,6 @@
-class SetMixin(object):
+from collections import MutableSet
+
+class SetMixin(MutableSet):
 
     """
     Mix-in for sets.  You must define __iter__, add, remove
@@ -16,93 +18,28 @@ class SetMixin(object):
                 return True
         return False
 
-    def issubset(self, other):
-        for item in other:
-            if item not in self:
-                return False
-        return True
+    issubset = MutableSet.__le__
+    issuperset = MutableSet.__ge__
 
-    __le__ = issubset
-
-    def issuperset(self, other):
-        for item in self:
-            if item not in other:
-                return False
-        return True
-
-    __ge__ = issuperset
-
-    def union(self, other):
-        return self | other
-
-    def __or__(self, other):
-        new = self.copy()
-        new |= other
-        return new
-    
-    def intersection(self, other):
-        return self & other
-
-    def __and__(self, other):
-        new = self.copy()
-        new &= other
-        return new
-
-    def difference(self, other):
-        return self - other
-
-    def __sub__(self, other):
-        new = self.copy()
-        new -= other
-        return new
-
-    def symmetric_difference(self, other):
-        return self ^ other
-
-    def __xor__(self, other):
-        new = self.copy()
-        new ^= other
-        return new
+    union = MutableSet.__or__
+    intersection = MutableSet.__and__
+    difference = MutableSet.__sub__
+    symmetric_difference = MutableSet.__xor__
 
     def copy(self):
         return set(self)
 
     def update(self, other):
-        for item in other:
-            self.add(item)
-
-    def __ior__(self, other):
-        self.update(other)
-        return self
+        self |= other
 
     def intersection_update(self, other):
-        for item in self:
-            if item not in other:
-                self.remove(item)
-
-    def __iand__(self, other):
-        self.intersection_update(other)
-        return self
+        self &= other
 
     def difference_update(self, other):
-        for item in other:
-            if item in self:
-                self.remove(item)
-
-    def __isub__(self, other):
-        self.difference_update(other)
-        return self
+        self -= other
 
     def symmetric_difference_update(self, other):
-        for item in other:
-            if item in self:
-                self.remove(item)
-            else:
-                self.add(item)
-
-    def __ixor__(self, other):
-        self.symmetric_difference_update(other)
-        return self
+        self ^= other
 
     def discard(self, item):
         try:
@@ -110,6 +47,6 @@ class SetMixin(object):
         except KeyError:
             pass
 
-    def clear(self):
-        for item in list(self):
-            self.remove(item)
+    @classmethod
+    def _from_iterable(cls, it):
+        return set(it)


### PR DESCRIPTION
SetMixin can't trivially be removed as:
* MutableSet annoyingly does not include the method form of the operators [on
  purpose](http://bugs.python.org/issue22089)
* SetMixin provides a ``copy`` which was only used internally (?) but may be
  used by third parties
Furthermore, because MutableSet and SetMixin differ in their abstract methods
(MutableSet uses discard rather than remove, and __len__ and __contains__ are
abstract) this would require significant edition of subclasses.

However rebuilding it on top of MutableSet significantly simplifies its implementation, much of which is simply aliasing the operator methods of MutableSet. This requires defining actual functions for in-place operators as the operators return `self` and the methods don't. This can also be useful to support multi-argument functions in the future if there ever is a need for it.

The diff could be simplified a bit (at the expense of final size) by leaving the old versions of `union`, `intersection`, `difference` and `symmetric_difference` as they called into the corresponding operator anyway.

`_from_iterable` was overridden to keep the current semantics of `union`/`intersection`/`difference`/`symmetric_difference` (returning a builtin `set`), MutableSet's default is to create a new object of the same type as the current one.