### PR TITLE
Fix soupparser support.

### DIFF
--- a/src/lxml/html/soupparser.py
+++ b/src/lxml/html/soupparser.py
@@ -105,8 +105,8 @@ def _convert_tree(beautiful_soup_tree, makeelement):
     if isinstance(decl, Declaration):
         m = declaration_re.match(decl.string)
         if not m:
-            # Could not parse doctype. Should we raise an exception?
-            # Print a warning message? Just let it pass?
+            # Something is wrong if we end up in here. Since soupparser should
+            # tolerate errors, do not raise Exception, just let it pass.
             pass
         else:
             g = m.groups()
@@ -121,11 +121,11 @@ def _convert_tree(beautiful_soup_tree, makeelement):
     if len(root) == 1 and root[0].name.lower() == 'html':
         res_root = makeelement(root[0].name,
                                attrib = dict(root[0].attrs),
-                               URI=uri, ExternalID=extid)
+                               doctype_uri=uri, external_id=extid)
         root = root[0].contents
     else:
         # Wrap all elements under a <html> tag, and process them.
-        res_root = makeelement('html', URI=uri, ExternalID=extid)
+        res_root = makeelement('html', doctype_uri=uri, external_id=extid)
 
     # Process descendants of the root
     _convert_children(res_root, root, makeelement)
@@ -144,7 +144,10 @@ def _convert_tree(beautiful_soup_tree, makeelement):
         elif isinstance(e, NavigableString) and e.string.strip() == '':
             pass
         else:
-            raise Exception('Invalid pre-root element %r' % e)
+            # Something is wrong if we end up in here. Since soupparser should
+            # tolerate errors, do not raise Exception, just let it pass.
+            pass
+
 
     # ditto for post_root
     prev = res_root
@@ -160,7 +163,7 @@ def _convert_tree(beautiful_soup_tree, makeelement):
         elif isinstance(e, NavigableString) and e.string.strip() == '':
             pass
         else:
-            raise Exception('Invalid post-root element %r' % e)
+            pass
 
     return res_root
 
@@ -181,7 +184,10 @@ def _convert_children(parent, beautiful_soup_tree, makeelement):
                 parent.append(etree.ProcessingInstruction(
                     *child.split(' ', 1)))
             elif isinstance(child, Declaration):
-                raise Exception('Document type declaration in the wrong place.')
+                # Something is wrong if we end up in here. Since
+                # soupparser should tolerate errors, do not raise
+                # Exception, just let it pass.
+                pass
             else: # CData
                 _append_text(parent, et_child, unescape(child))
 

--- a/src/lxml/html/soupparser.py
+++ b/src/lxml/html/soupparser.py
@@ -182,7 +182,6 @@ def _convert_children(parent, beautiful_soup_tree, makeelement):
                     *child.split(' ', 1)))
             elif isinstance(child, Declaration):
                 raise Exception('Document type declaration in the wrong place.')
-                pass
             else: # CData
                 _append_text(parent, et_child, unescape(child))
 

--- a/src/lxml/html/soupparser.py
+++ b/src/lxml/html/soupparser.py
@@ -3,9 +3,11 @@ __doc__ = """External interface to the BeautifulSoup HTML parser.
 
 __all__ = ["fromstring", "parse", "convert_tree"]
 
+import re
 from lxml import etree, html
 from BeautifulSoup import \
-     BeautifulSoup, Tag, Comment, ProcessingInstruction, NavigableString
+     BeautifulSoup, Tag, Comment, ProcessingInstruction, NavigableString, \
+     Declaration
 
 
 def fromstring(data, beautifulsoup=None, makeelement=None, **bsargs):
@@ -71,11 +73,96 @@ def _parse(source, beautifulsoup, makeelement, **bsargs):
     root.tag = "html"
     return root
 
+declaration_re = re.compile(r'DOCTYPE\s*HTML(?:\s+PUBLIC)?'
+'(?:\s+(\'[^\']*\'|"[^"]*"))?'  '(?:\s+(\'[^\']*\'|"[^"]*"))?', re.IGNORECASE)
+
 def _convert_tree(beautiful_soup_tree, makeelement):
-    root = makeelement(beautiful_soup_tree.name,
-                       attrib=dict(beautiful_soup_tree.attrs))
-    _convert_children(root, beautiful_soup_tree, makeelement)
-    return root
+    # Split the tree into three parts:
+    # i) everything before the root element: document type
+    # declaration, comments, processing instructions, whitespace
+    # ii) the root(s),
+    # iii) everything after the root: comments, processing
+    # instructions, whitespace
+    first_element_index, last_element_index = float('inf'), 0
+    for i, e in enumerate(beautiful_soup_tree):
+        if isinstance(e, Tag):
+            first_element_index = min(i, first_element_index)
+            last_element_index = i
+    last_element_index += 1
+
+    # For a nice, well-formatted document, root (below) is a list
+    # consisting of a single <html> tag. However, the document may be
+    # a soup like '<meta><head><title>Hello</head><body>Hi all<\p>'. In
+    # this example root is a list containing meta, head and body
+    # elements.
+    pre_root = beautiful_soup_tree.contents[:first_element_index]
+    root = beautiful_soup_tree.contents[first_element_index:last_element_index]
+    post_root = beautiful_soup_tree.contents[last_element_index:]
+
+    # Check if the documents starts with a document type declaration.
+    uri, extid = None, None
+    decl = pre_root[0] if len(pre_root) > 0 else None
+    if isinstance(decl, Declaration):
+        m = declaration_re.match(decl.string)
+        if not m:
+            # Could not parse doctype. Should we raise an exception?
+            # Print a warning message? Just let it pass?
+            pass
+        else:
+            g = m.groups()
+            extid, uri = '', ''
+            if len(g) >= 1 and g[0] is not None:
+                extid = g[0][1:-1] # [1:-1] strips quotes/hyphens
+            if len(g) >= 2 and g[1] is not None:
+                uri = g[1][1:-1] # [1:-1] strips quotes/hyphens
+        pre_root = pre_root[1:]
+
+    # Create root _Element which we shall return.
+    if len(root) == 1 and root[0].name.lower() == 'html':
+        res_root = makeelement(root[0].name,
+                               attrib = dict(root[0].attrs),
+                               URI=uri, ExternalID=extid)
+        root = root[0].contents
+    else:
+        # Wrap all elements under a <html> tag, and process them.
+        res_root = makeelement('html', URI=uri, ExternalID=extid)
+
+    # Process descendants of the root
+    _convert_children(res_root, root, makeelement)
+
+    # Process pre_root
+    prev = res_root
+    for e in reversed(pre_root):
+        if isinstance(e, Comment):
+            comment = etree.Comment(e)
+            prev.addprevious(comment)
+            prev = comment
+        elif isinstance(e, ProcessingInstruction):
+            PI = etree.ProcessingInstruction(*e.split(' ', 1))
+            prev.addprevious(PI)
+            prev = PI
+        elif isinstance(e, NavigableString) and e.string.strip() == '':
+            pass
+        else:
+            raise Exception('Invalid pre-root element %r' % e)
+
+    # ditto for post_root
+    prev = res_root
+    for e in post_root:
+        if isinstance(e, Comment):
+            comment = etree.Comment(e)
+            prev.addnext(comment)
+            prev = comment
+        elif isinstance(e, ProcessingInstruction):
+            PI = etree.ProcessingInstruction(*child.split(' ', 1))
+            prev.addnext(PI)
+            prev = PI
+        elif isinstance(e, NavigableString) and e.string.strip() == '':
+            pass
+        else:
+            raise Exception('Invalid post-root element %r' % e)
+
+    return res_root
 
 def _convert_children(parent, beautiful_soup_tree, makeelement):
     SubElement = etree.SubElement
@@ -93,6 +180,9 @@ def _convert_children(parent, beautiful_soup_tree, makeelement):
             elif isinstance(child, ProcessingInstruction):
                 parent.append(etree.ProcessingInstruction(
                     *child.split(' ', 1)))
+            elif isinstance(child, Declaration):
+                raise Exception('Document type declaration in the wrong place.')
+                pass
             else: # CData
                 _append_text(parent, et_child, unescape(child))
 
@@ -109,7 +199,6 @@ try:
     from html.entities import name2codepoint # Python 3
 except ImportError:
     from htmlentitydefs import name2codepoint
-import re
 
 handle_entities = re.compile("&(\w+);").sub
 

--- a/src/lxml/html/tests/test_elementsoup.py
+++ b/src/lxml/html/tests/test_elementsoup.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     BS_INSTALLED = False
 
+from lxml.html import tostring
+
 if BS_INSTALLED:
     class SoupParserTestCase(HelperTestCase):
         from lxml.html import soupparser
@@ -19,6 +21,83 @@ if BS_INSTALLED:
             """
             root = self.soupparser.fromstring(html)
             self.assertTrue(root.find('.//input').get('disabled') is not None)
+
+        def test_body(self):
+            html = '''<body><p>test</p></body>'''
+            res = '''<html><body><p>test</p></body></html>'''
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_body_comment(self):
+            html = '''<!-- comment --><body><p>test body</p></body>'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<!-- comment --><html><body><p>test body</p></body></html>'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tostring(tree), res)
+
+        def test_head_body(self):
+            html = '<head><title>test</title></head><body><p>test</p></body>'
+            res = '<html><head><title>test</title></head><body><p>test</p></body></html>'
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_comment1(self):
+            html = '''<!-- comment -->
+<?test asdf> 
+<head><title>test</title></head><body><p>test</p></body>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<!-- comment --><?test asdf?><html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tostring(tree), res)
+
+        def test_comment2(self):
+            html = '''<!-- comment -->
+<?test asdf>
+<html><head><title>test</title></head><body><p>test</p></body></html>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<!-- comment --><?test asdf?><html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tostring(tree), res)
+
+        def test_doctype1(self):
+            html = \
+'''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+ <html><head><title>My first HTML document</title></head><body><p>Hello world!</body></html>'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<html><head><title>My first HTML document</title></head><body><p>Hello world!</p></body></html>'''
+
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id, "-//W3C//DTD HTML 4.01//EN")
+            self.assertEquals(tostring(tree), res)
+
+
+        def test_doctype2(self):
+            html = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- comment --> 
+<?test asdf>
+<html><head><title>test</title></head><body><p>test</p></body></html>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!-- comment --><?test asdf?><html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id, "-//W3C//DTD XHTML 1.0 Strict//EN")
+            self.assertEquals(tostring(tree), res)
+
+        def test_doctype3(self):
+            # html 5 doctype declaration
+            html = '''<!DOCTYPE HTML>
+<html><head><title>test</title></head><body><p>test</p></body></html>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html>
+<html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id, "")
+            self.assertEquals(tostring(tree), res)
+
+
 
 
 def test_suite():

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -976,18 +976,18 @@ cdef class _BaseParser:
         return self._copy()
 
     def makeelement(self, _tag, attrib=None, nsmap=None,
-                    URI=None, ExternalID=None, **_extra):
+                    doctype_uri=None, external_id=None, **_extra):
         u"""makeelement(self, _tag, attrib=None, nsmap=None, **_extra)
 
         Creates a new element associated with this parser.
         """
-        if URI is not None and ExternalID is None:
+        if doctype_uri is not None and external_id is None:
             raise Exception('Doctype ExternalID cannot be None when URI is specified.')
-        if ExternalID is not None:
-            if URI == None:
-                c_doc = _newHTMLDoc(NULL, ExternalID)
+        if external_id is not None:
+            if doctype_uri is None:
+                c_doc = _newHTMLDoc(NULL, external_id)
             else:
-                c_doc = _newHTMLDoc(URI, ExternalID)
+                c_doc = _newHTMLDoc(doctype_uri, external_id)
         else:
             c_doc = NULL
         return _makeElement(_tag, c_doc, None, self, None, None,
@@ -1746,10 +1746,10 @@ cdef xmlDoc* _newXMLDoc() except NULL:
     __GLOBAL_PARSER_CONTEXT.initDocDict(result)
     return result
 
-cdef xmlDoc* _newHTMLDoc(const_xmlChar* URI=NULL,
-    const_xmlChar* ExternalID=NULL) except NULL:
+cdef xmlDoc* _newHTMLDoc(const_xmlChar* doctype_uri=NULL,
+    const_xmlChar* external_id=NULL) except NULL:
     cdef xmlDoc* result
-    result = tree.htmlNewDoc(URI, ExternalID)
+    result = tree.htmlNewDoc(doctype_uri, external_id)
     if result is NULL:
         raise MemoryError()
     __GLOBAL_PARSER_CONTEXT.initDocDict(result)


### PR DESCRIPTION
Soupparser did not properly handle doctypes or comments/processing instructions at root level, see https://bugs.launchpad.net/lxml/+bug/1341964. Fix that.