### PR TITLE
Fix unicode character checks.

### DIFF
--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1379,8 +1379,9 @@ cdef bytes _utf8(object s):
         valid = valid_xml_ascii(s)
         utf8_string = <bytes>s
     elif isinstance(s, unicode):
+        s = unicode(s)
         valid = valid_xml_unicode(s)
-        utf8_string = (<unicode>s).encode('utf8')
+        utf8_string = s.encode('utf8')
     elif isinstance(s, (bytes, bytearray)):
         utf8_string = bytes(s)
         valid = valid_xml_ascii(utf8_string)

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1382,8 +1382,8 @@ cdef bytes _utf8(object s):
         valid = valid_xml_unicode(s)
         utf8_string = (<unicode>s).encode('utf8')
     elif isinstance(s, (bytes, bytearray)):
-        valid = valid_xml_ascii(s)
         utf8_string = bytes(s)
+        valid = valid_xml_ascii(utf8_string)
     else:
         raise TypeError("Argument must be bytes or unicode, got '%.200s'" % type(s).__name__)
     if not valid:

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -60,6 +60,7 @@ cdef extern from "libxml/encoding.h":
 
 cdef extern from "libxml/chvalid.h":
     cdef int xmlIsChar_ch(char c) nogil
+    cdef int xmlIsCharQ(long c) nogil
 
 cdef extern from "libxml/hash.h":
     ctypedef struct xmlHashTable


### PR DESCRIPTION
As per XML standard, disallow characters #xD800-#xDFFF, #xFFFE, #xFFFF
in strings.

See also
http://stackoverflow.com/questions/23184263/central-way-to-filter-invalid-unicode-chars-in-lxml