### PR TITLE
Improve document type declaration processing

### DIFF
--- a/src/lxml/html/soupparser.py
+++ b/src/lxml/html/soupparser.py
@@ -3,9 +3,11 @@ __doc__ = """External interface to the BeautifulSoup HTML parser.
 
 __all__ = ["fromstring", "parse", "convert_tree"]
 
+import re
 from lxml import etree, html
 from BeautifulSoup import \
-     BeautifulSoup, Tag, Comment, ProcessingInstruction, NavigableString
+     BeautifulSoup, Tag, Comment, ProcessingInstruction, NavigableString, \
+     Declaration
 
 
 def fromstring(data, beautifulsoup=None, makeelement=None, **bsargs):
@@ -45,8 +47,6 @@ def convert_tree(beautiful_soup_tree, makeelement=None):
     You can pass a different Element factory through the `makeelement`
     keyword.
     """
-    if makeelement is None:
-        makeelement = html.html_parser.makeelement
     root = _convert_tree(beautiful_soup_tree, makeelement)
     children = root.getchildren()
     for child in children:
@@ -59,8 +59,6 @@ def convert_tree(beautiful_soup_tree, makeelement=None):
 def _parse(source, beautifulsoup, makeelement, **bsargs):
     if beautifulsoup is None:
         beautifulsoup = BeautifulSoup
-    if makeelement is None:
-        makeelement = html.html_parser.makeelement
     if 'convertEntities' not in bsargs:
         bsargs['convertEntities'] = 'html'
     tree = beautifulsoup(source, **bsargs)
@@ -71,11 +69,116 @@ def _parse(source, beautifulsoup, makeelement, **bsargs):
     root.tag = "html"
     return root
 
+declaration_re = re.compile(r'DOCTYPE\s*HTML(?:\s+PUBLIC)?'
+'(?:\s+(\'[^\']*\'|"[^"]*"))?'  '(?:\s+(\'[^\']*\'|"[^"]*"))?', re.IGNORECASE)
+
 def _convert_tree(beautiful_soup_tree, makeelement):
-    root = makeelement(beautiful_soup_tree.name,
-                       attrib=dict(beautiful_soup_tree.attrs))
-    _convert_children(root, beautiful_soup_tree, makeelement)
-    return root
+    # Split the tree into three parts:
+    # i) everything before the root element: document type
+    # declaration, comments, processing instructions, whitespace
+    # ii) the root(s),
+    # iii) everything after the root: comments, processing
+    # instructions, whitespace
+    first_element_idx, last_element_idx = float('inf'), 0
+    for i, e in enumerate(beautiful_soup_tree):
+        if isinstance(e, Tag):
+            first_element_idx = min(i, first_element_idx)
+            last_element_idx = i
+
+    # For a nice, well-formatted document, the variable root below is
+    # a list consisting of a single <html> element. However, the document
+    # may be a soup like '<meta><head><title>Hello</head><body>Hi
+    # all<\p>'. In this example root is a list containing meta, head
+    # and body elements.
+    pre_root = beautiful_soup_tree.contents[:first_element_idx]
+    root = beautiful_soup_tree.contents[first_element_idx:last_element_idx+1]
+    post_root = beautiful_soup_tree.contents[last_element_idx+1:]
+
+    # Check if the documents starts with a document type declaration.
+    external_id, sys_uri = None, None
+    for decl in pre_root:
+        if not isinstance(decl, Declaration):
+            continue
+        m = declaration_re.match(decl.string)
+        if not m:
+            # Something is wrong if we end up in here. Since soupparser should
+            # tolerate errors, do not raise Exception, just let it pass.
+            pass
+        else:
+            g = m.groups()
+            external_id, sys_uri = '', ''
+            if len(g) >= 1 and g[0] is not None:
+                external_id = g[0][1:-1] # [1:-1] strips quotes/hyphens
+            if len(g) >= 2 and g[1] is not None:
+                sys_uri = g[1][1:-1] # [1:-1] strips quotes/hyphens
+        pre_root.remove(decl)
+        break # Assume there is only one declaration, as there should.
+
+    # Create root _Element which we shall return.
+    if len(root) == 1 and root[0].name.lower() == 'html':
+        res_root_name = root[0].name
+        res_root_attrib = dict(root[0].attrs)
+        root_children = root[0].contents
+    else:
+        res_root_name = 'html'
+        res_root_attrib = { }
+        # Children of new, proper root are all current top-level elements.
+        root_children = root
+    if makeelement is None:
+        res_root = etree.HTMLParser().makehtmldocument(
+            external_id, sys_uri).getroot()
+        makeelement = html.html_parser.makeelement
+    else:
+        # We were given makeelement function, whose API most likely
+        # does not support setting document type declaration.  So the
+        # results declaration may be completely wrong, but there is
+        # nothing we can do.
+        res_root = makeelement(res_root_name, res_root_attrib)
+
+    # Process descendants of the root
+    _convert_children(res_root, root_children, makeelement)
+
+    # Process pre_root
+    prev = res_root
+    for e in reversed(pre_root):
+        if isinstance(e, Comment):
+            comment = etree.Comment(e)
+            prev.addprevious(comment)
+            prev = comment
+        elif isinstance(e, ProcessingInstruction):
+            args = e.split(' ', 1)
+            if args[1][-1] == '?':
+                args[1] = args[1][:-1]
+            PI = etree.ProcessingInstruction(*args)
+            prev.addprevious(PI)
+            prev = PI
+        elif isinstance(e, NavigableString) and e.string.strip() == '':
+            pass
+        else:
+            # Something is wrong if we end up in here. Since soupparser should
+            # tolerate errors, do not raise Exception, just let it pass.
+            pass
+
+    # ditto for post_root
+    prev = res_root
+    for e in post_root:
+        if isinstance(e, Comment):
+            comment = etree.Comment(e)
+            prev.addnext(comment)
+            prev = comment
+        elif isinstance(e, ProcessingInstruction):
+            args = e.split(' ', 1)
+            if args[1][-1] == '?':
+                args[1] = args[1][:-1]
+            PI = etree.ProcessingInstruction(*args)
+            prev.addnext(PI)
+            prev = PI
+        elif isinstance(e, NavigableString) and e.string.strip() == '':
+            pass
+        else:
+            pass
+
+    return res_root
 
 def _convert_children(parent, beautiful_soup_tree, makeelement):
     SubElement = etree.SubElement
@@ -91,8 +194,16 @@ def _convert_children(parent, beautiful_soup_tree, makeelement):
             if isinstance(child, Comment):
                 parent.append(etree.Comment(child))
             elif isinstance(child, ProcessingInstruction):
-                parent.append(etree.ProcessingInstruction(
-                    *child.split(' ', 1)))
+                args = e.split(' ', 1)
+                if args[1][-1] == '?':
+                    args[1] = args[1][:-1]
+                PI = etree.ProcessingInstruction(*args)
+                parent.append(PI)
+            elif isinstance(child, Declaration):
+                # Something is wrong if we end up in here. Since
+                # soupparser should tolerate errors, do not raise
+                # Exception, just let it pass.
+                pass
             else: # CData
                 _append_text(parent, et_child, unescape(child))
 
@@ -109,7 +220,6 @@ try:
     from html.entities import name2codepoint # Python 3
 except ImportError:
     from htmlentitydefs import name2codepoint
-import re
 
 handle_entities = re.compile("&(\w+);").sub
 

--- a/src/lxml/html/tests/test_elementsoup.py
+++ b/src/lxml/html/tests/test_elementsoup.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     BS_INSTALLED = False
 
+from lxml.html import tostring
+
 if BS_INSTALLED:
     class SoupParserTestCase(HelperTestCase):
         from lxml.html import soupparser
@@ -19,6 +21,50 @@ if BS_INSTALLED:
             """
             root = self.soupparser.fromstring(html)
             self.assertTrue(root.find('.//input').get('disabled') is not None)
+
+        def test_body(self):
+            html = '''<body><p>test</p></body>'''
+            res = '''<html><body><p>test</p></body></html>'''
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_head_body(self):
+            html = '<head><title>test</title></head><body><p>test</p></body>'
+            res = '<html><head><title>test</title></head><body><p>test</p></body></html>'
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_comment_pi(self):
+            html = '''<!-- comment -->
+<?test asdf>
+<head><title>test</title></head><body><p>test</p></body>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<!-- comment --><?test asdf?><html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tostring(tree), res)
+
+        def test_doctype1(self):
+            # Test document type declaration, comments and PI's
+            # outside the root
+            html = \
+'''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!--another comment--><html><head><title>My first HTML document</title></head><body><p>Hello world!</p></body></html><?foo bar?>'''
+
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id,
+                              "-//W3C//DTD HTML 4.01//EN")
+            self.assertEquals(tostring(tree), html)
+
+        def test_doctype2(self):
+            # html 5 doctype declaration
+            html = '<!DOCTYPE html>\n<html></html>'
+
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id, "")
+            self.assertEquals(tostring(tree), html)
+
+
 
 
 def test_suite():

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -373,6 +373,8 @@ cdef extern from "libxml/tree.h":
     cdef size_t xmlBufUse(xmlBuf* buf) nogil # new in libxml2 2.9
     cdef int xmlKeepBlanksDefault(int val) nogil
     cdef xmlChar* xmlNodeGetBase(xmlDoc* doc, xmlNode* node) nogil
+    cdef xmlDtd* xmlCreateIntSubset(xmlDoc* doc, const_xmlChar* name,
+                                    const_xmlChar* ExternalID, const_xmlChar* SystemID) nogil
     cdef void xmlNodeSetBase(xmlNode* node, const_xmlChar* uri) nogil
     cdef int xmlValidateNCName(const_xmlChar* value, int space) nogil
 

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -16,6 +16,7 @@ cdef extern from "libxml/xmlstring.h":
     cdef xmlChar* xmlStrdup(const_xmlChar* cur) nogil
     cdef int xmlStrncmp(const_xmlChar* str1, const_xmlChar* str2, int length) nogil
     cdef int xmlStrcmp(const_xmlChar* str1, const_xmlChar* str2) nogil
+    cdef int xmlStrcasecmp(const xmlChar *str1, const xmlChar *str2) nogil
     cdef const_xmlChar* xmlStrstr(const_xmlChar* str1, const_xmlChar* str2) nogil
     cdef const_xmlChar* xmlStrchr(const_xmlChar* str1, xmlChar ch) nogil
     cdef const_xmlChar* _xcstr "(const xmlChar*)PyBytes_AS_STRING" (object s)

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -577,16 +577,26 @@ cdef class DocInfo:
         u"Returns a DOCTYPE declaration string for the document."
         def __get__(self):
             root_name, public_id, system_url = self._doc.getdoctype()
+            if system_url:
+                # If system_url contains a quote, we must escape it
+                # with hyphens, otherwise escape with quotes. If url
+                # contains both quote and a hyphen, XML standard is
+                # being violated.
+                if system_url.find('"') != -1:
+                   escaped_system_url = u"'%s'" % system_url
+                else:
+                    escaped_system_url = u'"%s"' % system_url
             if public_id:
                 if system_url:
-                    return u'<!DOCTYPE %s PUBLIC "%s" "%s">' % (
-                        root_name, public_id, system_url)
+                    return u'<!DOCTYPE %s PUBLIC "%s" %s>' % (
+                        root_name, public_id, escaped_system_url)
+
                 else:
                     return u'<!DOCTYPE %s PUBLIC "%s">' % (
                         root_name, public_id)
             elif system_url:
-                return u'<!DOCTYPE %s SYSTEM "%s">' % (
-                    root_name, system_url)
+                return u'<!DOCTYPE %s SYSTEM %s>' % (
+                    root_name, escaped_system_url)
             elif self._doc.hasdoctype():
                 return u'<!DOCTYPE %s>' % root_name
             else:

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -218,7 +218,7 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
     # write internal DTD subset, preceding PIs/comments, etc.
     if write_complete_document and not c_buffer.error:
         if c_doctype is NULL:
-            _writeDtdToBuffer(c_buffer, c_doc, c_node.name, encoding)
+            _writeDtdToBuffer(c_buffer, c_doc, c_node.name, c_method, encoding)
         _writePrevSiblings(c_buffer, c_node, encoding, pretty_print)
 
     c_nsdecl_node = c_node
@@ -283,32 +283,54 @@ cdef int contains_quote(const_char* string) nogil:
 
 cdef void _writeDtdToBuffer(tree.xmlOutputBuffer* c_buffer,
                             xmlDoc* c_doc, const_xmlChar* c_root_name,
-                            const_char* encoding) nogil:
+                            int c_method, const_char* encoding) nogil:
     cdef tree.xmlDtd* c_dtd
     cdef xmlNode* c_node
     cdef char* escapechar
     c_dtd = c_doc.intSubset
     if not c_dtd or not c_dtd.name:
         return
-    if tree.xmlStrcmp(c_root_name, c_dtd.name) != 0:
-        return
+
+    # Name in document type declaration must match the root element tag.
+    # For XML, case sensitive match, for HTML insensitive.
+    if c_method == OUTPUT_METHOD_HTML:
+        if (tree.xmlStrcasecmp(c_root_name, "html") != 0 or
+            tree.xmlStrcasecmp(c_dtd.name, "html") != 0):
+            return
+    else:
+        if tree.xmlStrcmp(c_root_name, c_dtd.name) != 0:
+            return
+
     tree.xmlOutputBufferWrite(c_buffer, 10, "<!DOCTYPE ")
     tree.xmlOutputBufferWriteString(c_buffer, <const_char*>c_dtd.name)
-    if c_dtd.SystemID and c_dtd.SystemID[0] != c'\0':
-        if c_dtd.ExternalID != NULL and c_dtd.ExternalID[0] != c'\0':
-            tree.xmlOutputBufferWrite(c_buffer, 9, ' PUBLIC "')
-            tree.xmlOutputBufferWriteString(c_buffer, <const_char*>c_dtd.ExternalID)
-            tree.xmlOutputBufferWrite(c_buffer, 2, '" ')
-        else:
-            tree.xmlOutputBufferWrite(c_buffer, 8, ' SYSTEM ')
 
-        if contains_quote(<const_char*>c_dtd.SystemID):
-            escapechar = '\''
-        else:
-            escapechar = '"'
+    cdef const_xmlChar* public_id = c_dtd.ExternalID
+    cdef const_xmlChar* sys_url = c_dtd.SystemID
+    if public_id != NULL and public_id[0] == c'\0':
+        public_id = NULL
+    if sys_url != NULL and sys_url[0] == c'\0':
+        sys_url = NULL
+
+    if sys_url != NULL and contains_quote(<const_char*>sys_url):
+        escapechar = '\''
+    else:
+        escapechar = '"'
+
+    if public_id != NULL:
+        tree.xmlOutputBufferWrite(c_buffer, 9, ' PUBLIC "')
+        tree.xmlOutputBufferWriteString(c_buffer, <const_char*>public_id)
+        tree.xmlOutputBufferWrite(c_buffer, 1, '"')
+        if sys_url != NULL:
+            tree.xmlOutputBufferWrite(c_buffer, 1, ' ')
+            tree.xmlOutputBufferWrite(c_buffer, 1, escapechar)
+            tree.xmlOutputBufferWriteString(c_buffer, <const_char*>sys_url)
+            tree.xmlOutputBufferWrite(c_buffer, 1, escapechar)
+    elif sys_url != NULL:
+        tree.xmlOutputBufferWrite(c_buffer, 8, ' SYSTEM ')
         tree.xmlOutputBufferWrite(c_buffer, 1, escapechar)
-        tree.xmlOutputBufferWriteString(c_buffer, <const_char*>c_dtd.SystemID)
+        tree.xmlOutputBufferWriteString(c_buffer, <const_char*>sys_url)
         tree.xmlOutputBufferWrite(c_buffer, 1, escapechar)
+
     if not c_dtd.entities and not c_dtd.elements and \
            not c_dtd.attributes and not c_dtd.notations and \
            not c_dtd.pentities:

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -337,6 +337,32 @@ class ETreeDtdTestCase(HelperTestCase):
                          u'<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">')
         self.assertEqual(etree.tostring(doc, method='html'), html)
 
+    def test_set_decl_public(self):
+        doc = etree.Element('test').getroottree()
+        doc.setdoctype('bar', 'baz')
+        self.assertEqual(doc.docinfo.doctype,
+                         u'<!DOCTYPE test PUBLIC "bar" "baz">')
+        self.assertEqual(etree.tostring(doc),
+                         u'<!DOCTYPE test PUBLIC "bar" "baz">\n<test/>')
+
+    def test_set_decl_system(self):
+        doc = etree.Element('test').getroottree()
+        doc.setdoctype(None, 'baz')
+        self.assertEqual(doc.docinfo.doctype,
+                         u'<!DOCTYPE test SYSTEM "baz">')
+        self.assertEqual(etree.tostring(doc),
+                         u'<!DOCTYPE test SYSTEM "baz">\n<test/>')
+
+    def test_invalid_decl_1(self):
+        doc = etree.Element('test').getroottree()
+        with self.assertRaises(ValueError):
+            doc.setdoctype(u'\xe4', 'a')
+
+    def test_invalid_decl_2(self):
+        doc = etree.Element('test').getroottree()
+        with self.assertRaises(ValueError):
+            doc.setdoctype(u'a', '\'"')
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([unittest.makeSuite(ETreeDtdTestCase)])

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -328,6 +328,14 @@ class ETreeDtdTestCase(HelperTestCase):
         self.assertEqual(etree.tostring(doc),
                          '''<!DOCTYPE a SYSTEM "'">\n<a/>''')
 
+    def test_ietf_decl(self):
+        html = u'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">\n' \
+            u'<html></html>'
+        root = etree.HTML(html)
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype,
+                         u'<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">')
+        self.assertEqual(etree.tostring(doc, method='html'), html)
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -303,6 +303,31 @@ class ETreeDtdTestCase(HelperTestCase):
         self.assertEqual(dtd.name, "a")
         self.assertEqual(dtd.system_url, "test.dtd")
 
+    def test_declaration_escape_quote_pid(self):
+        # Standard allows quotes in systemliteral, but in that case
+        # systemliteral must be escaped with hyphens, not quotes.
+        # See http://www.w3.org/TR/REC-xml/#sec-prolog-dtd.
+        root = etree.XML('''<!DOCTYPE a PUBLIC 'foo' '"'><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype,
+                         u'''<!DOCTYPE a PUBLIC "foo" '"'>''')
+        self.assertEqual(etree.tostring(doc),
+                         '''<!DOCTYPE a PUBLIC "foo" '"'>\n<a/>''')
+
+    def test_declaration_escape_quote_withoutpid(self):
+        root = etree.XML('''<!DOCTYPE a SYSTEM '"'><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype, u'''<!DOCTYPE a SYSTEM '"'>''')
+        self.assertEqual(etree.tostring(doc),
+                         '''<!DOCTYPE a SYSTEM '"'>\n<a/>''')
+
+    def test_declaration_escape_hyphen(self):
+        root = etree.XML('''<!DOCTYPE a SYSTEM "'"><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype, u'''<!DOCTYPE a SYSTEM "'">''')
+        self.assertEqual(etree.tostring(doc),
+                         '''<!DOCTYPE a SYSTEM "'">\n<a/>''')
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -506,6 +506,20 @@ class HtmlParserTestCase(HelperTestCase):
             ("start", "html"), ("start", "body"),
             ("end", "body"), ("end", "html")], events)
 
+    def test_set_decl_html(self):
+        doc = etree.HTMLParser().makehtmldocument(
+            "-//W3C//DTD XHTML 1.0 Strict//EN",
+            "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd")
+        self.assertEqual(doc.docinfo.doctype,
+                         u'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">')
+
+    def test_invalid_decl_1(self):
+        with self.assertRaises(ValueError):
+            etree.HTMLParser().makehtmldocument(u'\xe4', 'a')
+
+    def test_invalid_decl_2(self):
+        with self.assertRaises(ValueError):
+            etree.HTMLParser().makehtmldocument(u'a', '"\'')
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
3 bugfixes and one improvement related to document type declarations:

 * Properly escape system literal which contains a quote character "
 * Properly serialize declarations in HTML
 * In elementsoup, fix processing of everything outside the root element (document type declaration, comments, processing instructions)
 * Set document type via lxml API (without parsing a document)