### PR TITLE
Improve document type declaration processing

### DIFF
--- a/src/lxml/html/tests/test_elementsoup.py
+++ b/src/lxml/html/tests/test_elementsoup.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     BS_INSTALLED = False
 
+from lxml.html import tostring
+
 if BS_INSTALLED:
     class SoupParserTestCase(HelperTestCase):
         from lxml.html import soupparser
@@ -20,6 +22,59 @@ if BS_INSTALLED:
             root = self.soupparser.fromstring(html)
             self.assertTrue(root.find('.//input').get('disabled') is not None)
 
+        def test_body(self):
+            html = '''<body><p>test</p></body>'''
+            res = '''<html><body><p>test</p></body></html>'''
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_head_body(self):
+            # HTML tag missing, parser should fix that
+            html = '<head><title>test</title></head><body><p>test</p></body>'
+            res = '<html><head><title>test</title></head><body><p>test</p></body></html>'
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_wrap_html(self):
+            # <head> outside <html>, parser should fix that
+            html = '<head><title>title</test></head><html><body/></html>'
+            res = '<html><head><title>title</title></head><body></body></html>'
+            tree = self.soupparser.fromstring(html)
+            self.assertEquals(tostring(tree), res)
+
+        def test_comment_pi(self):
+            html = '''<!-- comment -->
+<?test asdf?>
+<head><title>test</title></head><body><p>test</p></body>
+<!-- another comment -->'''
+            res = '''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<!-- comment --><?test asdf?><html><head><title>test</title></head><body><p>test</p></body></html><!-- another comment -->'''
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tostring(tree, method='html'), res)
+
+        def test_doctype1(self):
+            # Test document type declaration, comments and PI's
+            # outside the root
+            html = \
+'''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!--another comment--><html><head><title>My first HTML document</title></head><body><p>Hello world!</p></body></html><?foo bar>'''
+
+            res = \
+'''<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+<!--another comment--><html><head><title>My first HTML document</title></head><body><p>Hello world!</p></body></html><?foo bar?>'''
+
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertEquals(tree.docinfo.public_id,
+                              "-//W3C//DTD HTML 4.01//EN")
+            self.assertEquals(tostring(tree), res)
+
+        def test_doctype2(self):
+            # html 5 doctype declaration
+            html = '<!DOCTYPE html>\n<html lang="en"></html>'
+
+            tree = self.soupparser.fromstring(html).getroottree()
+            self.assertTrue(tree.docinfo.public_id is None)
+            self.assertEquals(tostring(tree), html)
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -373,6 +373,8 @@ cdef extern from "libxml/tree.h":
     cdef size_t xmlBufUse(xmlBuf* buf) nogil # new in libxml2 2.9
     cdef int xmlKeepBlanksDefault(int val) nogil
     cdef xmlChar* xmlNodeGetBase(xmlDoc* doc, xmlNode* node) nogil
+    cdef xmlDtd* xmlCreateIntSubset(xmlDoc* doc, const_xmlChar* name,
+                                    const_xmlChar* ExternalID, const_xmlChar* SystemID) nogil
     cdef void xmlNodeSetBase(xmlNode* node, const_xmlChar* uri) nogil
     cdef int xmlValidateNCName(const_xmlChar* value, int space) nogil
 

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -16,6 +16,7 @@ cdef extern from "libxml/xmlstring.h":
     cdef xmlChar* xmlStrdup(const_xmlChar* cur) nogil
     cdef int xmlStrncmp(const_xmlChar* str1, const_xmlChar* str2, int length) nogil
     cdef int xmlStrcmp(const_xmlChar* str1, const_xmlChar* str2) nogil
+    cdef int xmlStrcasecmp(const xmlChar *str1, const xmlChar *str2) nogil
     cdef const_xmlChar* xmlStrstr(const_xmlChar* str1, const_xmlChar* str2) nogil
     cdef const_xmlChar* xmlStrchr(const_xmlChar* str1, xmlChar ch) nogil
     cdef const_xmlChar* _xcstr "(const xmlChar*)PyBytes_AS_STRING" (object s)

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -506,6 +506,9 @@ cdef _Document _documentFactory(xmlDoc* c_doc, _BaseParser parser):
     return result
 
 
+nonwellformed_public_id = re.compile(
+                          "[^\x20\x0D\x0Aa-zA-Z0-9'()+,./:=?;!*#@$_%-]+")
+
 cdef class DocInfo:
     u"Document information provided by parser and DTD."
     cdef _Document _doc
@@ -522,17 +525,92 @@ cdef class DocInfo:
             root_name, public_id, system_url = self._doc.getdoctype()
             return root_name
 
+    @cython.final
+    cdef tree.xmlDtd* get_c_dtd(self):
+        u"""Return the DTD. Create it if it does not yet exist."""
+        cdef xmlDoc* c_doc = self._doc._c_doc
+        cdef xmlNode* c_root_node
+        cdef const_xmlChar* c_name
+
+        if c_doc.intSubset == NULL:
+            c_root_node = tree.xmlDocGetRootElement(c_doc)
+            if c_root_node is NULL:
+                c_name = NULL
+            else:
+                name = _utf8(c_root_node.name)
+                c_name = _xcstr(name)
+            if tree.xmlCreateIntSubset(c_doc, c_name, NULL, NULL) is NULL:
+                raise MemoryError()
+        return c_doc.intSubset
+
+    def clear(self):
+        u"""Removes the DOCTYPE from the document."""
+        cdef xmlDoc* c_doc = self._doc._c_doc
+        cdef tree.xmlDtd* c_dtd = c_doc.intSubset
+        if c_dtd is NULL:
+            return
+        tree.xmlUnlinkNode(<xmlNode*>c_dtd)
+        tree.xmlFreeNode(<xmlNode*>c_dtd)
+
     property public_id:
-        u"Returns the public ID of the DOCTYPE."
+        u"""Public ID of the DOCTYPE.
+
+	Mutable. May be set to a valid string or None. If a DTD does not
+	exist, setting this variable (even to None) will create one.
+        """
         def __get__(self):
             root_name, public_id, system_url = self._doc.getdoctype()
             return public_id
 
+        def __set__(self, value):
+            cdef tree.xmlDtd* c_dtd = self.get_c_dtd()
+            cdef const_xmlChar* c_value = NULL
+
+            if value is not None:
+                m = nonwellformed_public_id.match(value)
+                if m:
+                    raise ValueError('Invalid character(s) %r in public_id.' %
+                        m.group(0))
+                value = _utf8(value)
+                c_value = tree.xmlStrdup(_xcstr(value))
+                if c_value == NULL:
+                    raise MemoryError()
+
+            if c_dtd.ExternalID != NULL:
+                tree.xmlFree(c_dtd.ExternalID)
+
+            c_dtd.ExternalID = c_value
+
     property system_url:
-        u"Returns the system ID of the DOCTYPE."
+        u"""System ID of the DOCTYPE.
+
+	Mutable. May be set to a valid string or None. If a DTD does not
+	exist, setting this variable (even to None) will create one.
+        """
         def __get__(self):
             root_name, public_id, system_url = self._doc.getdoctype()
             return system_url
+
+        def __set__(self, value):
+            cdef tree.xmlDtd* c_dtd = self.get_c_dtd()
+            cdef const_xmlChar* c_value = NULL
+
+            if value is not None:
+                # sys_url may be any valid unicode string that can be
+                # enclosed in single quotes or quotes.
+                if "'" in value and '"' in value:
+                    raise ValueError('System URL may not contain both a '
+                        'single quote (\') and a quote (").')
+
+                value = _utf8(value)
+                c_value = tree.xmlStrdup(_xcstr(value))
+                if c_value == NULL:
+                    raise MemoryError()
+
+            if c_dtd.SystemID != NULL:
+                tree.xmlFree(c_dtd.SystemID)
+
+            c_dtd.SystemID = c_value
 
     property xml_version:
         u"Returns the XML version as declared by the document."

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -577,16 +577,25 @@ cdef class DocInfo:
         u"Returns a DOCTYPE declaration string for the document."
         def __get__(self):
             root_name, public_id, system_url = self._doc.getdoctype()
+            if system_url:
+                # If '"' in system_url, we must escape it with single
+                # quotes, otherwise escape with double quotes. If url
+                # contains both a single quote and a double quote, XML
+                # standard is being violated.
+                if system_url.find('"') != -1:
+                    quoted_system_url = u"'%s'" % system_url
+                else:
+                    quoted_system_url = u'"%s"' % system_url
             if public_id:
                 if system_url:
-                    return u'<!DOCTYPE %s PUBLIC "%s" "%s">' % (
-                        root_name, public_id, system_url)
+                    return u'<!DOCTYPE %s PUBLIC "%s" %s>' % (
+                        root_name, public_id, quoted_system_url)
                 else:
                     return u'<!DOCTYPE %s PUBLIC "%s">' % (
                         root_name, public_id)
             elif system_url:
-                return u'<!DOCTYPE %s SYSTEM "%s">' % (
-                    root_name, system_url)
+                return u'<!DOCTYPE %s SYSTEM %s>' % (
+                    root_name, quoted_system_url)
             elif self._doc.hasdoctype():
                 return u'<!DOCTYPE %s>' % root_name
             else:

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -280,6 +280,7 @@ cdef void _writeDtdToBuffer(tree.xmlOutputBuffer* c_buffer,
                             const_char* encoding) nogil:
     cdef tree.xmlDtd* c_dtd
     cdef xmlNode* c_node
+    cdef char* quotechar
     c_dtd = c_doc.intSubset
     if not c_dtd or not c_dtd.name:
         return
@@ -291,11 +292,17 @@ cdef void _writeDtdToBuffer(tree.xmlOutputBuffer* c_buffer,
         if c_dtd.ExternalID != NULL and c_dtd.ExternalID[0] != c'\0':
             tree.xmlOutputBufferWrite(c_buffer, 9, ' PUBLIC "')
             tree.xmlOutputBufferWriteString(c_buffer, <const_char*>c_dtd.ExternalID)
-            tree.xmlOutputBufferWrite(c_buffer, 3, '" "')
+            tree.xmlOutputBufferWrite(c_buffer, 2, '" ')
         else:
-            tree.xmlOutputBufferWrite(c_buffer, 9, ' SYSTEM "')
+            tree.xmlOutputBufferWrite(c_buffer, 8, ' SYSTEM ')
+
+        if tree.xmlStrchr(<const_xmlChar*>c_dtd.SystemID, c'"'):
+            quotechar = '\''
+        else:
+            quotechar = '"'
+        tree.xmlOutputBufferWrite(c_buffer, 1, quotechar)
         tree.xmlOutputBufferWriteString(c_buffer, <const_char*>c_dtd.SystemID)
-        tree.xmlOutputBufferWrite(c_buffer, 1, '"')
+        tree.xmlOutputBufferWrite(c_buffer, 1, quotechar)
     if not c_dtd.entities and not c_dtd.elements and \
            not c_dtd.attributes and not c_dtd.notations and \
            not c_dtd.pentities:

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -213,6 +213,11 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
     cdef xmlDoc* c_doc = c_node.doc
     if write_xml_declaration and c_method == OUTPUT_METHOD_XML:
         _writeDeclarationToBuffer(c_buffer, c_doc.version, encoding, standalone)
+
+    # comments/processing instructions before doctype declaration
+    if write_complete_document and not c_buffer.error and c_doc.intSubset:
+        _writePrevSiblings(c_buffer, <xmlNode*>c_doc.intSubset, encoding, pretty_print)
+
     if c_doctype:
         _writeDoctype(c_buffer, c_doctype)
     # write internal DTD subset, preceding PIs/comments, etc.

--- a/src/lxml/tests/common_imports.py
+++ b/src/lxml/tests/common_imports.py
@@ -15,7 +15,7 @@ try:
 except:
     from urllib.request import pathname2url
 
-from lxml import etree
+from lxml import etree, html
 
 def make_version_tuple(version_string):
     l = []

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -393,6 +393,13 @@ class ETreeDtdTestCase(HelperTestCase):
             doc.docinfo.system_url = '\'"'
         self.assertRaises(ValueError, setsystemurl)
 
+    def test_comment_before_dtd(self):
+        data = '<!--comment--><!DOCTYPE test>\n<!-- --><test/>'
+        doc = etree.fromstring(data).getroottree()
+        self.assertEqual(etree.tostring(doc),
+                         _bytes(data))
+
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([unittest.makeSuite(ETreeDtdTestCase)])

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -328,6 +328,14 @@ class ETreeDtdTestCase(HelperTestCase):
         self.assertEqual(etree.tostring(doc),
                          _bytes('''<!DOCTYPE a SYSTEM "'">\n<a/>'''))
 
+    def test_ietf_decl(self):
+        html = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">\n' \
+            '<html></html>'
+        root = etree.HTML(html)
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype,
+                         '<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">')
+        self.assertEqual(etree.tostring(doc, method='html'), _bytes(html))
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -303,6 +303,31 @@ class ETreeDtdTestCase(HelperTestCase):
         self.assertEqual(dtd.name, "a")
         self.assertEqual(dtd.system_url, "test.dtd")
 
+    def test_declaration_escape_quote_pid(self):
+        # Standard allows quotes in systemliteral, but in that case
+        # systemliteral must be escaped with single quotes.
+        # See http://www.w3.org/TR/REC-xml/#sec-prolog-dtd.
+        root = etree.XML('''<!DOCTYPE a PUBLIC 'foo' '"'><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype,
+                         '''<!DOCTYPE a PUBLIC "foo" '"'>''')
+        self.assertEqual(etree.tostring(doc),
+                         _bytes('''<!DOCTYPE a PUBLIC "foo" '"'>\n<a/>'''))
+
+    def test_declaration_quote_withoutpid(self):
+        root = etree.XML('''<!DOCTYPE a SYSTEM '"'><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype, '''<!DOCTYPE a SYSTEM '"'>''')
+        self.assertEqual(etree.tostring(doc),
+                         _bytes('''<!DOCTYPE a SYSTEM '"'>\n<a/>'''))
+
+    def test_declaration_apos(self):
+        root = etree.XML('''<!DOCTYPE a SYSTEM "'"><a/>''')
+        doc = root.getroottree()
+        self.assertEqual(doc.docinfo.doctype, '''<!DOCTYPE a SYSTEM "'">''')
+        self.assertEqual(etree.tostring(doc),
+                         _bytes('''<!DOCTYPE a SYSTEM "'">\n<a/>'''))
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
4 bugfixes and one improvement related to document type declarations:

* Properly escape system literal which contains a quote character "
* Properly serialize HTML declarations
* In elementsoup, fix processing of everything outside the root element (document type declaration, comments, processing instructions)
* Set/remove document type via lxml API
* Properly serialize comments & processing instructions which precede document type declaration