### PR TITLE
Fix _ElementTree.deepcopy()

### DIFF
--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -1921,13 +1921,9 @@ cdef public class _ElementTree [ type LxmlElementTreeType,
             # so what ...
             return self
 
-    # not in ElementTree, read-only
+    # not in ElementTree
     property docinfo:
-        u"""Information about the document provided by parser and DTD.  This
-        value is only defined for ElementTree objects based on the root node
-        of a parsed document (e.g.  those returned by the parse functions),
-        not for trees that were built manually.
-        """
+        u"""Information about the document provided by parser and DTD."""
         def __get__(self):
             self._assertHasRoot()
             return DocInfo(self._context_node._doc)

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -1903,12 +1903,6 @@ cdef public class _ElementTree [ type LxmlElementTreeType,
             assert root is not None
             _assertValidNode(root)
             _copyNonElementSiblings(self._context_node._c_node, root._c_node)
-            doc = root._doc
-            c_doc = self._context_node._doc._c_doc
-            if c_doc.intSubset is not NULL and doc._c_doc.intSubset is NULL:
-                doc._c_doc.intSubset = _copyDtd(c_doc.intSubset)
-            if c_doc.extSubset is not NULL and not doc._c_doc.extSubset is NULL:
-                doc._c_doc.extSubset = _copyDtd(c_doc.extSubset)
             return _elementTreeFactory(None, root)
         elif self._doc is not None:
             _assertValidDoc(self._doc)

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -576,6 +576,17 @@ class ETreeOnlyTestCase(HelperTestCase):
         self.assertEqual(_bytes("<test/>"),
                           tostring(root2))
 
+    def test_deepcopy_pi_dtd(self):
+        XML = self.etree.XML
+        tostring = self.etree.tostring
+        xml = _bytes('<!-- comment --><!DOCTYPE test [\n<!ENTITY entity "tasty">\n]>\n<test/>')
+        root = XML(xml)
+        tree1 = self.etree.ElementTree(root)
+        self.assertEqual(xml, tostring(tree1))
+
+        tree2 = copy.deepcopy(tree1)
+        self.assertEqual(xml, tostring(tree2))
+
     def test_parse_remove_comments(self):
         fromstring = self.etree.fromstring
         tostring = self.etree.tostring


### PR DESCRIPTION
As I was experimenting with alternative serialization, I found a bug in _ElementTree.deepcopy().

    >>> import lxml.etree, copy
    >>> doc = lxml.etree.fromstring('<!--comment--><!DOCTYPE test><test/>').getroottree()
    >>> doc2 = copy.deepcopy(doc)
    >>> lxml.etree.tostring(doc2)
    '<!DOCTYPE test>\n<test/>'

Of course you would expect to get `'<!--comment--><!DOCTYPE test>\n<test/>'`.


