### PR TITLE
Unicode & string processing

### DIFF
--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1334,24 +1334,43 @@ cdef inline int isutf8(const_xmlChar* s):
         c = s[0]
     return 0
 
-cdef int check_string_utf8(bytes pystring):
-    u"""Check if a string looks like valid UTF-8 XML content.  Returns 0
-    for ASCII, 1 for UTF-8 and -1 in the case of errors, such as NULL
-    bytes or ASCII control characters.
-    """
+cdef int valid_xml_ascii(bytes pystring):
+    """Check if a string is XML ascii content."""
+    cdef signed char ch
+    # When ch is a *signed* char, non-ascii characters are negative integers
+    # and xmlIsChar_ch does not accept them.
+    for ch in pystring:
+        if not tree.xmlIsChar_ch(ch):
+            return 0
+    return 1
+
+def valid_xml_utf8(bytes pystring):
+    u"""Check if a string is like valid UTF-8 XML content."""
     cdef const_xmlChar* s = _xcstr(pystring)
     cdef const_xmlChar* c_end = s + len(pystring)
-    cdef bint is_non_ascii = 0
+    cdef unsigned long next3 = 0
+    if s+2 < c_end:
+        next3 = (s[0] << 16) | (s[1] << 8) | (s[2])
+
     while s < c_end:
         if s[0] & 0x80:
-            # skip over multi byte sequences
-            while s < c_end and s[0] & 0x80:
-                s += 1
-            is_non_ascii = 1
-        if  s < c_end and not tree.xmlIsChar_ch(s[0]):
-            return -1 # invalid!
+            # 0xefbfbe and 0xefbfbf are utf-8 encodings of
+            # forbidden characters \ufffe and \uffff
+            if next3 == 0x00efbfbe or next3 == 0x00efbfbf:
+                return 0
+            # 0xeda080 and 0xedbfbf are utf-8 encodings of
+            # \ud800 and \udfff. Anything between them (inclusive)
+            # is forbidden, because they are surrogate blocks in utf-16.
+            if next3 >= 0x00eda080 and next3 <= 0x00edbfbf:
+                return 0
+        else:
+            if not tree.xmlIsChar_ch(s[0]):
+                return 0 # invalid ascii char
+
         s += 1
-    return is_non_ascii
+        if s+2 < c_end:
+            next3 = 0x00ffffff & ((next3 << 8) | s[2])
+    return 1
 
 cdef inline object funicodeOrNone(const_xmlChar* s):
     return funicode(s) if s is not NULL else None
@@ -1384,20 +1403,20 @@ cdef bytes _utf8(object s):
     Reject all bytes/unicode input that contains non-XML characters.
     Reject all bytes input that contains non-ASCII characters.
     """
-    cdef int invalid
+    cdef int valid
     cdef bytes utf8_string
     if not python.IS_PYTHON3 and type(s) is bytes:
         utf8_string = <bytes>s
-        invalid = check_string_utf8(utf8_string)
+        valid = valid_xml_ascii(utf8_string)
     elif isinstance(s, unicode):
         utf8_string = (<unicode>s).encode('utf8')
-        invalid = check_string_utf8(utf8_string) == -1 # non-XML?
+        valid = valid_xml_utf8(utf8_string)
     elif isinstance(s, (bytes, bytearray)):
         utf8_string = bytes(s)
-        invalid = check_string_utf8(utf8_string)
+        valid = valid_xml_ascii(utf8_string)
     else:
         raise TypeError("Argument must be bytes or unicode, got '%.200s'" % type(s).__name__)
-    if invalid:
+    if not valid:
         raise ValueError(
             "All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters")
     return utf8_string
@@ -1474,7 +1493,7 @@ cdef object _encodeFilenameUTF8(object filename):
     if filename is None:
         return None
     elif isinstance(filename, bytes):
-        if not check_string_utf8(<bytes>filename):
+        if not isutf8(<bytes>filename):
             # plain ASCII!
             return filename
         c_filename = _cstr(<bytes>filename)

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1566,13 +1566,13 @@ cdef tuple __getNsTag(tag, bint empty_ns):
     return ns, tag
 
 cdef inline int _pyXmlNameIsValid(name_utf8):
-    return _xmlNameIsValid(_xcstr(name_utf8))
+    return _xmlNameIsValid(_xcstr(name_utf8)) and b':' not in name_utf8
 
 cdef inline int _pyHtmlNameIsValid(name_utf8):
     return _htmlNameIsValid(_xcstr(name_utf8))
 
 cdef inline int _xmlNameIsValid(const_xmlChar* c_name):
-    return tree.xmlValidateNCName(c_name, 0) == 0
+    return tree.xmlValidateNameValue(c_name)
 
 cdef int _htmlNameIsValid(const_xmlChar* c_name):
     if c_name is NULL or c_name[0] == c'\0':

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1424,6 +1424,15 @@ cdef bytes _utf8(object s):
 cdef bytes _utf8orNone(object s):
     return _utf8(s) if s is not None else None
 
+cdef inline stringrepr(s):
+    """Give an representation of strings which we can use in __repr__
+    methods, e.g. _Element.__repr__().
+    """
+    if python.IS_PYTHON3:
+        return s
+    else:
+        return s.encode('unicode-escape')
+
 cdef bint _isFilePath(const_xmlChar* c_path):
     u"simple heuristic to see if a path is a filename"
     cdef xmlChar c

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -391,6 +391,7 @@ cdef extern from "libxml/valid.h":
     cdef xmlAttr* xmlGetID(xmlDoc* doc, const_xmlChar* ID) nogil
     cdef void xmlDumpNotationTable(xmlBuffer* buffer,
                                    xmlNotationTable* table) nogil
+    cdef int xmlValidateNameValue(const_xmlChar* value) nogil
 
 cdef extern from "libxml/xmlIO.h":
     cdef int xmlOutputBufferWrite(xmlOutputBuffer* out,

--- a/src/lxml/lxml.etree.pyx
+++ b/src/lxml/lxml.etree.pyx
@@ -1134,7 +1134,7 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
     # ACCESSORS
     def __repr__(self):
         u"__repr__(self)"
-        return u"<Element %s at 0x%x>" % (self.tag, id(self))
+        return "<Element %s at 0x%x>" % (stringrepr(self.tag), id(self))
 
     def __getitem__(self, x):
         u"""Returns the subelement at the given position or the requested
@@ -1685,7 +1685,7 @@ cdef class _Comment(__ContentOnlyElement):
             return Comment
 
     def __repr__(self):
-        return u"<!--%s-->" % self.text
+        return "<!--%s-->" % stringrepr(self.text)
     
 cdef class _ProcessingInstruction(__ContentOnlyElement):
     property tag:
@@ -1707,9 +1707,10 @@ cdef class _ProcessingInstruction(__ContentOnlyElement):
     def __repr__(self):
         text = self.text
         if text:
-            return u"<?%s %s?>" % (self.target, text)
+            return "<?%s %s?>" % (stringrepr(self.target),
+                                  stringrepr(text))
         else:
-            return u"<?%s?>" % self.target
+            return "<?%s?>" % stringrepr(self.target)
 
     def get(self, key, default=None):
         u"""get(self, key, default=None)
@@ -1763,7 +1764,7 @@ cdef class _Entity(__ContentOnlyElement):
             return u'&%s;' % funicode(self._c_node.name)
 
     def __repr__(self):
-        return u"&%s;" % self.name
+        return "&%s;" % stringrepr(self.name)
 
 
 cdef class QName:

--- a/src/lxml/lxml.objectify.pyx
+++ b/src/lxml/lxml.objectify.pyx
@@ -39,6 +39,17 @@ import re
 cdef tuple IGNORABLE_ERRORS = (ValueError, TypeError)
 cdef object is_special_method = re.compile(u'__.*__$').match
 
+# Duplicated from apihelpers.pxi, since dependencies obstruct
+# including apihelpers.pxi.
+cdef inline stringrepr(s):
+    """Give an representation of strings which we can use in __repr__
+    methods, e.g. _Element.__repr__().
+    """
+    if python.IS_PYTHON3:
+        return s
+    else:
+        return s.encode('unicode-escape')
+
 cdef object _typename(object t):
     cdef const_char* c_name
     c_name = python._fqtypename(t)
@@ -592,10 +603,10 @@ cdef class ObjectifiedDataElement(ObjectifiedElement):
             return textOf(self._c_node)
 
     def __str__(self):
-        return textOf(self._c_node) or u''
+        return textOf(self._c_node) or ''
 
     def __repr__(self):
-        return textOf(self._c_node) or u''
+        return stringrepr(textOf(self._c_node) or '')
 
     def _setText(self, s):
         u"""For use in subclasses only. Don't use unless you know what you are
@@ -779,7 +790,7 @@ cdef class NoneElement(ObjectifiedDataElement):
         return u"None"
 
     def __repr__(self):
-        return u"None"
+        return "None"
 
     def __nonzero__(self):
         return False
@@ -927,7 +938,7 @@ cdef class PyType:
         self._schema_types = []
 
     def __repr__(self):
-        return u"PyType(%s, %s)" % (self.name, self._type.__name__)
+        return "PyType(%s, %s)" % (self.name, self._type.__name__)
 
     def register(self, before=None, after=None):
         u"""register(self, before=None, after=None)

--- a/src/lxml/readonlytree.pxi
+++ b/src/lxml/readonlytree.pxi
@@ -85,17 +85,17 @@ cdef class _ReadOnlyProxy:
     def __repr__(self):
         self._assertNode()
         if self._c_node.type == tree.XML_ELEMENT_NODE:
-            return u"<Element %s at 0x%x>" % (self.tag, id(self))
+            return "<Element %s at 0x%x>" % (stringrepr(self.tag), id(self))
         elif self._c_node.type == tree.XML_COMMENT_NODE:
-            return u"<!--%s-->" % self.text
+            return "<!--%s-->" % stringrepr(self.text)
         elif self._c_node.type == tree.XML_ENTITY_NODE:
-            return u"&%s;" % funicode(self._c_node.name)
+            return "&%s;" % stringrepr(funicode(self._c_node.name))
         elif self._c_node.type == tree.XML_PI_NODE:
             text = self.text
             if text:
-                return u"<?%s %s?>" % (self.target, text)
+                return "<?%s %s?>" % (stringrepr(self.target), text)
             else:
-                return u"<?%s?>" % self.target
+                return "<?%s?>" % stringrepr(self.target)
         else:
             self._raise_unsupported_type()
 

--- a/src/lxml/tests/common_imports.py
+++ b/src/lxml/tests/common_imports.py
@@ -142,9 +142,14 @@ if sys.version_info[0] >= 3:
                 doctests, {}, os.path.basename(filename), filename, 0))
 else:
     # Python 2
+    unichr_escape = re.compile(r'\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}')
+
     from __builtin__ import unicode
     def _str(s, encoding="UTF-8"):
-        return unicode(s, encoding=encoding)
+        s = unicode(s, encoding=encoding)
+        return unichr_escape.sub(lambda x:
+                                     x.group(0).decode('unicode-escape'),
+                                 s)
     def _bytes(s, encoding="UTF-8"):
         return s
     from io import BytesIO

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3818,6 +3818,29 @@ class ETreeOnlyTestCase(HelperTestCase):
             data = zlib.decompress(data)
         return canonicalize(data)
 
+    def test_unicode(self):
+        e  = self.etree.Element('e')
+        def settext(text):
+            e.text = text
+
+        self.assertRaises(ValueError, settext, _str('ab\ufffe'))
+        self.assertRaises(ValueError, settext, _str('ö\ffff'))
+        self.assertRaises(ValueError, settext, _str('\u0123\ud800'))
+        self.assertRaises(ValueError, settext, _str('x\ud8ff'))
+        self.assertRaises(ValueError, settext, _str('\U00010000\udfff'))
+        self.assertRaises(ValueError, settext, _str('abd\x00def'))
+        # should not Raise
+        settext(_str('\ud7ff\ue000\U00010000\U0010FFFFäöas'))
+
+        self.assertRaises(ValueError, settext, _bytes('\xe4'))
+        self.assertRaises(ValueError, settext, _bytes('\x80'))
+        self.assertRaises(ValueError, settext, _bytes('\xff'))
+        self.assertRaises(ValueError, settext, _bytes('\x08'))
+        self.assertRaises(ValueError, settext, _bytes('\x19'))
+        self.assertRaises(ValueError, settext, _bytes('\x20\x00'))
+        # should not Raise
+        settext(_bytes('\x09\x0A\x0D\x20\x60\x7f'))
+
 class _XIncludeTestCase(HelperTestCase):
     def test_xinclude_text(self):
         filename = fileInTestDir('test_broken.xml')

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3858,6 +3858,17 @@ class ETreeOnlyTestCase(HelperTestCase):
         # should not Raise
         settext(_bytes('\x09\x0A\x0D\x20\x60\x7f'))
 
+    def test_uniname(self):
+        Element = self.etree.Element
+        def el(name):
+            return Element(name)
+
+        self.assertRaises(ValueError, el, ':')
+        self.assertRaises(ValueError, el, '0a')
+        self.assertRaises(ValueError, el, _str('\u203f'))
+        # should not Raise
+        el(_str('\u0132'))
+
 class _XIncludeTestCase(HelperTestCase):
     def test_xinclude_text(self):
         filename = fileInTestDir('test_broken.xml')

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3818,7 +3818,6 @@ class ETreeOnlyTestCase(HelperTestCase):
             data = zlib.decompress(data)
         return canonicalize(data)
 
-
 class _XIncludeTestCase(HelperTestCase):
     def test_xinclude_text(self):
         filename = fileInTestDir('test_broken.xml')

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3818,6 +3818,23 @@ class ETreeOnlyTestCase(HelperTestCase):
             data = zlib.decompress(data)
         return canonicalize(data)
 
+    def test_unicode_repr1(self):
+        x = self.etree.Element(_str('å'))
+        # must not raise UnicodeEncodeError
+        repr(x)
+
+    def test_unicode_repr2(self):
+        x = self.etree.Comment(_str('ö'))
+        repr(x)
+
+    def test_unicode_repr3(self):
+        x = self.etree.ProcessingInstruction(_str('Å'), _str('\u0131'))
+        repr(x)
+
+    def test_unicode_repr4(self):
+        x = self.etree.Entity(_str('ä'))
+        repr(x)
+
     def test_unicode(self):
         e  = self.etree.Element('e')
         def settext(text):

--- a/src/lxml/tests/test_unicode.py
+++ b/src/lxml/tests/test_unicode.py
@@ -28,6 +28,12 @@ uxml = _bytes("<test><title>test \\xc3\\xa1\\u3120</title><h1>page \\xc3\\xa1\\u
 
 
 class UnicodeTestCase(HelperTestCase):
+    def test__str(self):
+        # test the testing framework, namely _str from common_imports
+        self.assertEqual(_str('\x10'), _str('\u0010'))
+        self.assertEqual(_str('\x10'), _str('\U00000010'))
+        self.assertEqual(_str('\u1234'), _str('\U00001234'))
+
     def test_unicode_xml(self):
         tree = etree.XML('<p>%s</p>' % uni)
         self.assertEqual(uni, tree.text)


### PR DESCRIPTION
Commits related to strings, encodings, and allowed characters.

 * Check that all strings consists of allowed XML characters (no` \ufffe`, `\uffff`, or surrogates).
 * Check that names are valid as specified in current XML standard, which is more tolerant than earlier, outdated editions (http://www.w3.org/TR/REC-xml/#NT-Name vs. http://www.w3.org/TR/2006/REC-xml-20060816/#NT-Name)
 * Python 2 expects `__repr__` to return `str`, not `unicode`, and wrong type may lead to UnicodeEncodeError. Fix this.
 * Some test contained `_str('ha\u1234\x07ho')` or similar things. The `\u` escape does not work on python 2 `''` string, unless we do some magic.