### PR TITLE
Failing ISOSchematron validation on report

### DIFF
--- a/src/lxml/isoschematron/__init__.py
+++ b/src/lxml/isoschematron/__init__.py
@@ -226,7 +226,7 @@ class Schematron(_etree._Validator):
     def __init__(self, etree=None, file=None, include=True, expand=True,
                  include_params={}, expand_params={}, compile_params={},
                  store_schematron=False, store_xslt=False, store_report=False,
-                 phase=None, fail_on_report=True):
+                 phase=None, fail_on_report=False):
         super(Schematron, self).__init__()
 
         self._store_report = store_report

--- a/src/lxml/isoschematron/__init__.py
+++ b/src/lxml/isoschematron/__init__.py
@@ -65,6 +65,9 @@ iso_svrl_for_xslt1 = _etree.XSLT(_etree.parse(
 # svrl result accessors
 svrl_validation_errors = _etree.XPath(
     '//svrl:failed-assert', namespaces={'svrl': SVRL_NS})
+    
+svrl_validation_errors_complete = _etree.XPath(
+    '//svrl:failed-assert | //svrl:successful-report', namespaces={'svrl': SVRL_NS})
 
 
 # RelaxNG validator for schematron schemas
@@ -148,7 +151,10 @@ class Schematron(_etree._Validator):
 
     Schematron is a less well known, but very powerful schema language.  The main
     idea is to use the capabilities of XPath to put restrictions on the structure
-    and the content of XML documents.  Here is a simple example::
+    and the content of XML documents.
+    Notice that standard behaviour is to fail only on assert. To also cause a 
+    failed validation with report element ``fail_on_report`` must be set to True.
+    Here is a simple example::
 
       >>> from lxml import isoschematron
       >>> schematron = isoschematron.Schematron(etree.XML('''
@@ -162,7 +168,7 @@ class Schematron(_etree._Validator):
       ...     </rule>
       ...   </pattern>
       ... </schema>
-      ... '''))
+      ... '''), fail_on_report=True)
 
       >>> xml = etree.XML('''
       ... <AAA name="aaa">
@@ -172,7 +178,7 @@ class Schematron(_etree._Validator):
       ... ''')
 
       >>> schematron.validate(xml)
-      0
+      False
 
       >>> xml = etree.XML('''
       ... <AAA id="aaa">
@@ -182,7 +188,7 @@ class Schematron(_etree._Validator):
       ... ''')
 
       >>> schematron.validate(xml)
-      1
+      True
     """
 
     # libxml2 error categorization for validation errors
@@ -220,7 +226,7 @@ class Schematron(_etree._Validator):
     def __init__(self, etree=None, file=None, include=True, expand=True,
                  include_params={}, expand_params={}, compile_params={},
                  store_schematron=False, store_xslt=False, store_report=False,
-                 phase=None):
+                 phase=None, fail_on_report=True):
         super(Schematron, self).__init__()
 
         self._store_report = store_report
@@ -269,6 +275,8 @@ class Schematron(_etree._Validator):
         if store_xslt:
             self._validator_xslt = validator_xslt
         self._validator = _etree.XSLT(validator_xslt)
+        if fail_on_report:
+            self._validation_errors = svrl_validation_errors_complete
         
     def __call__(self, etree):
         """Validate doc using Schematron.

--- a/src/lxml/tests/test_isoschematron.py
+++ b/src/lxml/tests/test_isoschematron.py
@@ -14,6 +14,7 @@ if this_dir not in sys.path:
 from common_imports import etree, HelperTestCase, fileInTestDir
 from common_imports import doctest, make_doctest
 
+
 class ETreeISOSchematronTestCase(HelperTestCase):
     def test_schematron(self):
         tree_valid = self.parse('<AAA><BBB/><CCC/></AAA>')
@@ -37,6 +38,7 @@ class ETreeISOSchematronTestCase(HelperTestCase):
     </pattern>
 </schema>
 ''')
+
         schema = isoschematron.Schematron(schema)
         self.assertTrue(schema.validate(tree_valid))
         self.assertTrue(not schema.validate(tree_invalid))
@@ -838,6 +840,26 @@ class ETreeISOSchematronTestCase(HelperTestCase):
         self.assertTrue(not schema.validate(tree_invalid))
 
     #TODO: test xslt parameters for inclusion, expand & compile steps (?)
+
+    def test_schematron_fail_on_report(self):
+        tree_valid = self.parse('<AAA><BBB/><CCC/></AAA>')
+        tree_invalid = self.parse('<AAA><BBB/><CCC/><DDD/></AAA>')
+        schema = self.parse('''\
+<schema xmlns="http://purl.oclc.org/dsdl/schematron" >
+    <pattern id="OpenModel">
+        <title>Simple Report</title>
+        <rule context="AAA">
+            <report test="DDD"> DDD element must not be present</report>
+        </rule>
+    </pattern>
+</schema>
+''')
+        schema_report = isoschematron.Schematron(schema, fail_on_report=True)
+        schema_no_report = isoschematron.Schematron(schema)
+        self.assertTrue(schema_report.validate(tree_valid))
+        self.assertTrue(not schema_report.validate(tree_invalid))
+        self.assertTrue(schema_no_report.validate(tree_valid))
+        self.assertTrue(schema_no_report.validate(tree_invalid))
 
 
 def test_suite():


### PR DESCRIPTION
Standard behaviour in lxml.isoschematron.Schematron is to fail validation only on assert, ignoring any report. Failure on report can be achieved subclassing and customizing the Schematron class. Anyway an easy switch in the constructor to enable failure on report could be useful.
 