### PR TITLE
Remove bugtrack_url because it causes warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,11 @@ setup(
     maintainer_email="lxml-dev@lxml.de",
     url="http://lxml.de/",
     download_url="http://pypi.python.org/packages/source/l/lxml/lxml-%s.tar.gz" % lxml_version,
-    bugtrack_url="https://bugs.launchpad.net/lxml",
+
+    # Commented out because this causes distutils to emit warnings
+    # `Unknown distribution option: 'bugtrack_url'`
+    # which distract folks from real causes of problems when troubleshooting
+    # bugtrack_url="https://bugs.launchpad.net/lxml",
 
     description="Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API.",
 


### PR DESCRIPTION
I don't think `bugtrack_url` has any effect on PyPI (you have to set the bugtrack_url in the PyPI UI I believe) and this causes a `Unknown distribution option: 'bugtrack_url'` warning to be emitted when installing or building a wheel.

    $ pip wheel lxml
    Collecting lxml
      Using cached lxml-3.4.2.tar.gz
        /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'bugtrack_url'
          warnings.warn(msg)