### PR TITLE
Fix selector cache in ElementPath

### DIFF
--- a/src/lxml/_elementpath.py
+++ b/src/lxml/_elementpath.py
@@ -234,8 +234,9 @@ def _build_path_iterator(path, namespaces):
         raise ValueError("empty namespace prefix is not supported in ElementPath")
     if path[-1:] == "/":
         path += "*"  # implicit all (FIXME: keep this?)
+    cache_key = (path, namespaces and tuple(sorted(namespaces.items())) or None)
     try:
-        return _cache[(path, namespaces and tuple(sorted(namespaces.items())) or None)]
+        return _cache[cache_key]
     except KeyError:
         pass
     if len(_cache) > 100:
@@ -265,7 +266,7 @@ def _build_path_iterator(path, namespaces):
                 token = _next()
         except StopIteration:
             break
-    _cache[path] = selector
+    _cache[cache_key] = selector
     return selector
 
 


### PR DESCRIPTION
Origin of the problem: 8bafbdc13ffb4fb8436eda01594780aac4735528.