### PR TITLE
Make html5parser put elements into void namespace

### DIFF
--- a/doc/html5parser.txt
+++ b/doc/html5parser.txt
@@ -17,6 +17,8 @@ to the ``lxml.html`` module by providing ``fromstring()``,
 ``fragments_fromstring()`` that work like the regular html parsing
 functions.
 
+Note that, as with the ``lxml.html`` module, this module also ignores
+namespaces.
 
 Differences to regular HTML parsing
 ===================================

--- a/src/lxml/html/html5parser.py
+++ b/src/lxml/html/html5parser.py
@@ -29,7 +29,7 @@ class HTMLParser(_HTMLParser):
     """An html5lib HTML parser with lxml as tree."""
 
     def __init__(self, strict=False, **kwargs):
-        _HTMLParser.__init__(self, strict=strict, tree=TreeBuilder, **kwargs)
+        _HTMLParser.__init__(self, strict=strict, tree=TreeBuilder, namespaceHTMLElements=False, **kwargs)
 
 
 try:


### PR DESCRIPTION
I would think that most lxml users would be happy if html5parser ignored namespaces in the same way that lxml.html does (so that they could write code with lxml that basically works the same way no matter which parser they use.

See the comment at https://bugs.launchpad.net/lxml/+bug/1191545/comments/2 from html5lib maintainer @gsnedders:

> html5lib follows what the HTML spec requires and puts HTML elements in the HTML namespace. If one wants to more-or-less match the behaviour of lxml.html, one can use the namespaceHTMLElements=False argument on html5lib.html5parser.HTMLParser and html5lib.html5parser.parse to put HTML elements in the void namespace (note that SVG and MathML elements are still put in their respective namespaces).

https://html.spec.whatwg.org/multipage/syntax.html#the-before-html-insertion-mode is where the relevant requirement is stated, in the step labeled **A start tag whose tag name is "html"**:

> Create an element for the token in the HTML namespace…

I would be extremely happy to contribute tests for this change if it is accepted.
