### PR TITLE
Clarify cleaner doc on setting `comments=False`

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -109,7 +109,8 @@ class Cleaner(object):
         as they could contain Javascript.
 
     ``comments``:
-        Removes any comments.
+        Removes any comments. If you set it to False, keep in mind that 
+        ``processing_instructions`` also removes comments).
 
     ``style``:
         Removes any style tags or attributes.


### PR DESCRIPTION
Maybe the actual way to go is to remove [this rule](https://github.com/lxml/lxml/blob/11e7f9a7d98e96ad31a1d5991b57d47472c1d143/src/lxml/html/clean.py#L308) you seem not to be sure about. The sure thing is that the effect is quite unexpected for the library user: "I cannot disable comments removing".
