### PR TITLE
Treat None parameter as no parameter when creating elements

### DIFF
--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -218,6 +218,8 @@ class ElementMaker(object):
             get(dict)(elem, attrib)
 
         for item in children:
+            if item is None:
+                continue
             if callable(item):
                 item = item()
             t = get(type(item))


### PR DESCRIPTION
The E-factory won't accept None as a valid argument, but I feel like it should treat this the same as when it does not receive any arguments.

I don't know if there is a good reason it raises an exception in this case, but this small commit "fixes" it.