### PR TITLE
Do not blindly copy all of the namespaces when tostring():ing a subtree.

### DIFF
--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -233,7 +233,7 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node, bint u
     c_parent = c_from_node.parent
     cdef _nscache c_ns_cache = [NULL, 0, 0]
     cdef _ns_update_map c_ns_entry
-    cdef bint apply_ns = 0
+    cdef bint should_copy = 0
 
     if used_only:
         # Build up a cache for each of the ns prefixes used in the elements we will
@@ -258,13 +258,13 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node, bint u
         c_new_ns = c_parent.nsDef
         while c_new_ns:
             if used_only:
-                apply_ns = 0
+                should_copy = 0
                 for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
                     if c_new_ns is c_ns_entry.old:
-                        apply_ns = 1
+                        should_copy = 1
                         break
 
-            if not used_only or apply_ns:
+            if not used_only or should_copy:
                 # libxml2 will check if the prefix is already defined
                 tree.xmlNewNs(c_to_node, c_new_ns.href, c_new_ns.prefix)
             c_new_ns = c_new_ns.next

--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -223,7 +223,7 @@ cdef int canDeallocateChildNodes(xmlNode* c_parent):
 ################################################################################
 # fix _Document references and namespaces when a node changes documents
 
-cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node):
+cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node) nogil:
     u"""Copy the namespaces of all ancestors of c_from_node to c_to_node that are used by c_to_node.
     """
     cdef xmlNode* c_parent
@@ -248,7 +248,8 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node):
                 break
 
         if c_ns is NULL:
-            _appendToNsCache(&c_ns_cache, c_node.ns, NULL)
+            with gil:
+                _appendToNsCache(&c_ns_cache, c_node.ns, NULL)
     tree.END_FOR_EACH_ELEMENT_FROM(c_node)
 
     while c_parent and (tree._isElementOrXInclude(c_parent) or

--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -233,7 +233,7 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node):
     cdef int prefix_known
     c_parent = c_from_node.parent
     cdef _nscache c_ns_cache = [NULL, 0, 0]
-    cdef size_t i
+    cdef _ns_update_map c_ns_entry
 
     # Build up a cache for each of the ns prefixes used in the elements we will
     # copy over, then use prescence in the cache as a basis for allowing the
@@ -242,9 +242,9 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node):
     tree.BEGIN_FOR_EACH_ELEMENT_FROM(c_from_node, c_node, 1)
     if c_node.ns is not NULL:
         c_ns = NULL
-        for i in range(int(c_ns_cache.last)):
-            if c_node.ns is c_ns_cache.ns_map[i].old:
-                c_ns = c_ns_cache.ns_map[i].old
+        for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
+            if c_node.ns is c_ns_entry.old:
+                c_ns = c_ns_entry.old
                 break
 
         if c_ns is NULL:
@@ -256,8 +256,8 @@ cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node):
         c_new_ns = c_parent.nsDef
         while c_new_ns:
             ns_in_use = 0
-            for i in range(c_ns_cache.last):
-                if c_new_ns is c_ns_cache.ns_map[i].old:
+            for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
+                if c_new_ns is c_ns_entry.old:
                     ns_in_use = 1
                     break
 

--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -84,7 +84,7 @@ cdef xmlDoc* _fakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node) except NULL:
     return _plainFakeRootDoc(c_base_doc, c_node, 1, 0)
 
 cdef xmlDoc* _plainFakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node,
-                               bint with_siblings, bint used_only) except NULL:
+                               bint with_siblings, bint used_only=1) except NULL:
     # build a temporary document that has the given node as root node
     # note that copy and original must not be modified during its lifetime!!
     # always call _destroyFakeDoc() after use!
@@ -223,7 +223,7 @@ cdef int canDeallocateChildNodes(xmlNode* c_parent):
 ################################################################################
 # fix _Document references and namespaces when a node changes documents
 
-cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node, bint used_only) nogil:
+cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node, bint used_only=1) nogil:
     u"""Copy the namespaces of all ancestors of c_from_node to c_to_node that are used by c_to_node.
     """
     cdef xmlNode* c_parent

--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -81,10 +81,10 @@ cdef inline int _unregisterProxy(_Element proxy) except -1:
 # temporarily make a node the root node of its document
 
 cdef xmlDoc* _fakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node) except NULL:
-    return _plainFakeRootDoc(c_base_doc, c_node, 1)
+    return _plainFakeRootDoc(c_base_doc, c_node, 1, 0)
 
 cdef xmlDoc* _plainFakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node,
-                               bint with_siblings) except NULL:
+                               bint with_siblings, bint applied_ns_only) except NULL:
     # build a temporary document that has the given node as root node
     # note that copy and original must not be modified during its lifetime!!
     # always call _destroyFakeDoc() after use!
@@ -101,7 +101,7 @@ cdef xmlDoc* _plainFakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node,
     c_doc  = _copyDoc(c_base_doc, 0)                   # non recursive!
     c_new_root = tree.xmlDocCopyNode(c_node, c_doc, 2) # non recursive!
     tree.xmlDocSetRootElement(c_doc, c_new_root)
-    _copyParentNamespaces(c_node, c_new_root)
+    _copyParentNamespaces(c_node, c_new_root, applied_ns_only)
 
     c_new_root.children = c_node.children
     c_new_root.last = c_node.last
@@ -223,46 +223,48 @@ cdef int canDeallocateChildNodes(xmlNode* c_parent):
 ################################################################################
 # fix _Document references and namespaces when a node changes documents
 
-cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node) nogil:
+cdef void _copyParentNamespaces(xmlNode* c_from_node, xmlNode* c_to_node, bint applied_ns_only) nogil:
     u"""Copy the namespaces of all ancestors of c_from_node to c_to_node that are used by c_to_node.
     """
     cdef xmlNode* c_parent
     cdef xmlNode* c_node
     cdef xmlNs* c_ns
     cdef xmlNs* c_new_ns
-    cdef int prefix_known
     c_parent = c_from_node.parent
     cdef _nscache c_ns_cache = [NULL, 0, 0]
     cdef _ns_update_map c_ns_entry
+    cdef bint apply_ns = 0
 
-    # Build up a cache for each of the ns prefixes used in the elements we will
-    # copy over, then use prescence in the cache as a basis for allowing the
-    # copy of the namespace.
-    c_node = c_from_node.children
-    tree.BEGIN_FOR_EACH_ELEMENT_FROM(c_from_node, c_node, 1)
-    if c_node.ns is not NULL:
-        c_ns = NULL
-        for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
-            if c_node.ns is c_ns_entry.old:
-                c_ns = c_ns_entry.old
-                break
+    if applied_ns_only:
+        # Build up a cache for each of the ns prefixes used in the elements we will
+        # copy over, then use prescence in the cache as a basis for allowing the
+        # copy of the namespace.
+        c_node = c_from_node.children
+        tree.BEGIN_FOR_EACH_ELEMENT_FROM(c_from_node, c_node, 1)
+        if c_node.ns is not NULL:
+            c_ns = NULL
+            for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
+                if c_node.ns is c_ns_entry.old:
+                    c_ns = c_ns_entry.old
+                    break
 
-        if c_ns is NULL:
-            with gil:
-                _appendToNsCache(&c_ns_cache, c_node.ns, NULL)
-    tree.END_FOR_EACH_ELEMENT_FROM(c_node)
+            if c_ns is NULL:
+                with gil:
+                    _appendToNsCache(&c_ns_cache, c_node.ns, NULL)
+        tree.END_FOR_EACH_ELEMENT_FROM(c_node)
 
     while c_parent and (tree._isElementOrXInclude(c_parent) or
                         c_parent.type == tree.XML_DOCUMENT_NODE):
         c_new_ns = c_parent.nsDef
         while c_new_ns:
-            ns_in_use = 0
-            for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
-                if c_new_ns is c_ns_entry.old:
-                    ns_in_use = 1
-                    break
+            if applied_ns_only:
+                apply_ns = 0
+                for c_ns_entry in c_ns_cache.ns_map[:c_ns_cache.last]:
+                    if c_new_ns is c_ns_entry.old:
+                        apply_ns = 1
+                        break
 
-            if ns_in_use:
+            if not applied_ns_only or apply_ns:
                 # libxml2 will check if the prefix is already defined
                 tree.xmlNewNs(c_to_node, c_new_ns.href, c_new_ns.prefix)
             c_new_ns = c_new_ns.next

--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -81,7 +81,8 @@ cdef inline int _unregisterProxy(_Element proxy) except -1:
 # temporarily make a node the root node of its document
 
 cdef xmlDoc* _fakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node) except NULL:
-    return _plainFakeRootDoc(c_base_doc, c_node, 1, 0)
+    return _plainFakeRootDoc(c_base_doc=c_base_doc, c_node=c_node,
+                with_siblings=1, used_only=0)
 
 cdef xmlDoc* _plainFakeRootDoc(xmlDoc* c_base_doc, xmlNode* c_node,
                                bint with_siblings, bint used_only=1) except NULL:

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -159,7 +159,8 @@ cdef bytes _tostringC14N(element_or_tree, bint exclusive, bint with_comments, in
     if isinstance(element_or_tree, _Element):
         _assertValidNode(<_Element>element_or_tree)
         doc = (<_Element>element_or_tree)._doc
-        c_doc = _plainFakeRootDoc(doc._c_doc, (<_Element>element_or_tree)._c_node, 0, 1)
+        c_doc = _plainFakeRootDoc(c_base_doc=doc._c_doc, c_node=(<_Element>element_or_tree)._c_node,
+                        with_siblings=0, used_only=1)
     else:
         doc = _documentOrRaise(element_or_tree)
         _assertValidDoc(doc)
@@ -234,7 +235,7 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
         if not c_nsdecl_node:
             c_buffer.error = xmlerror.XML_ERR_NO_MEMORY
             return
-        _copyParentNamespaces(c_node, c_nsdecl_node, 0)
+        _copyParentNamespaces(c_from_node=c_node, c_to_node=c_nsdecl_node, used_only=0)
 
         c_nsdecl_node.parent = c_node.parent
         c_nsdecl_node.children = c_node.children

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -159,7 +159,7 @@ cdef bytes _tostringC14N(element_or_tree, bint exclusive, bint with_comments, in
     if isinstance(element_or_tree, _Element):
         _assertValidNode(<_Element>element_or_tree)
         doc = (<_Element>element_or_tree)._doc
-        c_doc = _plainFakeRootDoc(doc._c_doc, (<_Element>element_or_tree)._c_node, 0)
+        c_doc = _plainFakeRootDoc(doc._c_doc, (<_Element>element_or_tree)._c_node, 0, 1)
     else:
         doc = _documentOrRaise(element_or_tree)
         _assertValidDoc(doc)
@@ -234,7 +234,7 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
         if not c_nsdecl_node:
             c_buffer.error = xmlerror.XML_ERR_NO_MEMORY
             return
-        _copyParentNamespaces(c_node, c_nsdecl_node)
+        _copyParentNamespaces(c_node, c_nsdecl_node, 0)
 
         c_nsdecl_node.parent = c_node.parent
         c_nsdecl_node.children = c_node.children

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -234,8 +234,7 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
         if not c_nsdecl_node:
             c_buffer.error = xmlerror.XML_ERR_NO_MEMORY
             return
-        with gil:
-            _copyParentNamespaces(c_node, c_nsdecl_node)
+        _copyParentNamespaces(c_node, c_nsdecl_node)
 
         c_nsdecl_node.parent = c_node.parent
         c_nsdecl_node.children = c_node.children

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -234,7 +234,8 @@ cdef void _writeNodeToBuffer(tree.xmlOutputBuffer* c_buffer,
         if not c_nsdecl_node:
             c_buffer.error = xmlerror.XML_ERR_NO_MEMORY
             return
-        _copyParentNamespaces(c_node, c_nsdecl_node)
+        with gil:
+            _copyParentNamespaces(c_node, c_nsdecl_node)
 
         c_nsdecl_node.parent = c_node.parent
         c_nsdecl_node.children = c_node.children

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -4194,14 +4194,14 @@ class ETreeC14NTestCase(HelperTestCase):
                           s)
 
         s = etree.tostring(tree.getroot()[0], method='c14n', exclusive=False)
-        self.assertEqual(_bytes('<z:b xmlns="http://abc" xmlns:y="http://bcd" xmlns:z="http://cde"></z:b>'),
+        self.assertEqual(_bytes('<z:b xmlns:z="http://cde"></z:b>'),
                           s)
         s = etree.tostring(tree.getroot()[0], method='c14n', exclusive=True)
         self.assertEqual(_bytes('<z:b xmlns:z="http://cde"></z:b>'),
                           s)
 
         s = etree.tostring(tree.getroot()[0], method='c14n', exclusive=True, inclusive_ns_prefixes=['y'])
-        self.assertEqual(_bytes('<z:b xmlns:y="http://bcd" xmlns:z="http://cde"></z:b>'),
+        self.assertEqual(_bytes('<z:b xmlns:z="http://cde"></z:b>'),
                           s)
 
     def test_c14n_tostring_inclusive_ns_prefixes(self):


### PR DESCRIPTION
When using a subtree of a document do not simply copy all of the
namespaces from all of the parents down. Only copy those that we
actually use within the subtree. This as copying all namespaces will
bloat the subtree with information it should not have.

This might seem harmless to do in the average case, but it will cause problems when serializing the XML, specifically C14N serialization which will according to specification retain all ns declarations on the root level element. So if this tostring() execution then will insert all parent namespace declarations into the now new root element we will unnecessarily bloat the ns declarations on this new toplevel element. 

Having this said I am not confident this is the best code for doing this, feel free to point me in the direction of better code if you will. 