### PR TITLE
Fix unichr bug on Python3

### DIFF
--- a/src/lxml/html/soupparser.py
+++ b/src/lxml/html/soupparser.py
@@ -291,6 +291,13 @@ except ImportError:
 handle_entities = re.compile("&(\w+);").sub
 
 
+try:
+    unichr
+except NameError:
+    # Python 3
+    unichr = chr
+
+
 def unescape(string):
     if not string:
         return ''


### PR DESCRIPTION
The unescape function in `soupparser.py` uses `unichr` which doesn't exist in Python 3.