### PR TITLE
Replace ftplib with urllib to pick up ftp_proxy when building lxml with STATIC_DEPS=true

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -3,11 +3,11 @@ import tarfile
 from distutils import log, sysconfig, version
 
 try:
-    from urlparse import urlsplit, urljoin
-    from urllib import urlretrieve
+    from urlparse import urlsplit, urljoin, unquote
+    from urllib import urlretrieve, urlopen
 except ImportError:
-    from urllib.parse import urlsplit, urljoin
-    from urllib.request import urlretrieve
+    from urllib.parse import urlsplit, urljoin, unquote
+    from urllib.request import urlretrieve, urlopen
 
 multi_make_options = []
 try:
@@ -100,13 +100,34 @@ LIBICONV_LOCATION = 'ftp://ftp.gnu.org/pub/gnu/libiconv/'
 match_libfile_version = re.compile('^[^-]*-([.0-9-]+)[.].*').match
 
 def ftp_listdir(url):
-    import ftplib, posixpath
-    scheme, netloc, path, qs, fragment = urlsplit(url)
-    assert scheme.lower() == 'ftp'
-    server = ftplib.FTP(netloc)
-    server.login()
-    files = [posixpath.basename(fn) for fn in server.nlst(path)]
+    assert url.lower().startswith('ftp://')
+    from email.message import Message
+    res = urlopen(url)
+    content_type = res.headers.get('Content-Type')
+    if content_type:
+        msg = Message()
+        msg.add_header('Content-Type', content_type)
+        charset = msg.get_content_charset('utf-8')
+    else:
+        charset = 'utf-8'
+    if content_type and content_type.startswith('text/html'):
+        files = parse_html_ftplist(res.read().decode(charset))
+    else:
+        files = parse_text_ftplist(res.read().decode(charset))
+    res.close()
     return files
+
+def parse_text_ftplist(s):
+    for line in s.splitlines():
+        if not line.startswith('d'):
+            yield line[54:].strip()
+
+def parse_html_ftplist(s):
+    re_href = re.compile(r'<a\s+(?:[^>]*?\s+)?href=["\'](.*?)[;\?"\']', re.I|re.M)
+    links = set(re_href.findall(s))
+    for link in links:
+        if not link.endswith('/'):
+            yield unquote(link)
 
 def tryint(s):
     try:

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -120,7 +120,9 @@ def ftp_listdir(url):
 def parse_text_ftplist(s):
     for line in s.splitlines():
         if not line.startswith('d'):
-            yield line[54:].strip()
+            # -rw-r--r--   1 ftp      ftp           476 Sep  1  2011 md5sum.txt
+            # Last (9th) element is 'md5sum.txt' in the above example.
+            yield line.split(None, 9)[-1]
 
 def parse_html_ftplist(s):
     re_href = re.compile(r'<a\s+(?:[^>]*?\s+)?href=["\'](.*?)[;\?"\']', re.I|re.M)


### PR DESCRIPTION
I'm not sure if this pull-request has right direction but I've made small change to overcome following problem which I have. It'll be more than great if you'd merge this PR, provide feedback on this PR or anything else. Thanks in advance.

**Problem**
I want to realize CI of one Python project which uses lxml and other modules. To make preparation simple in CI, all of dependencies are written in ```requirements.txt``` and ready to be installed by ```pip install -r requirements.txt```. Because the Python project is targeting Windows environment, I've also set up ```STATIC_DEPS=true``` in CI job.

However, build of lxml fails on CI servers because of no direct access to the Internet; Other modules are able to be installed through proxy server (with ```http_proxy``` and ```https_proxy``` environmental variables) but lxml is not because of usage of ftplib which doesn't take care of ```ftp_proxy``` environmental variable.

```
Downloading lxml-3.5.0.tar.gz (3.8MB)
Downloading from URL https://pypi.python.org/packages/source/l/lxml/lxml-3.5.0.tar.gz#md5=9f0c5f1eb43ff44d5455dab4b4efbe73 (from https://pypi.python.org/simple/lxml/)
Running setup.py (path:C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\setup.py) egg_info for package lxml
  Running command python setup.py egg_info
  Building lxml version 3.5.0.
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\setup.py", line 233, in <module>
      **setup_extra_options()
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\setup.py", line 144, in setup_extra_options
      STATIC_CFLAGS, STATIC_BINARIES)
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\setupinfo.py", line 55, in ext_modules
      OPTION_DOWNLOAD_DIR, static_include_dirs, static_library_dirs)
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\buildlibxml.py", line 86, in get_prebuilt_libxml2xslt
      libs = download_and_extract_zlatkovic_binaries(download_dir)
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\buildlibxml.py", line 34, in download_and_extract_zlatkovic_binaries
      for fn in ftp_listdir(url):
    File "C:\Users\ADMINI~1\AppData\Local\Temp\pip-build-trs2ox77\lxml\buildlibxml.py", line 106, in ftp_listdir
      server = ftplib.FTP(netloc)
    File "C:\Python34\lib\ftplib.py", line 118, in __init__
      self.connect(host)
    File "C:\Python34\lib\ftplib.py", line 153, in connect
      source_address=self.source_address)
    File "C:\Python34\lib\socket.py", line 512, in create_connection
      raise err
    File "C:\Python34\lib\socket.py", line 503, in create_connection
      sock.connect(sa)
  TimeoutError: [WinError 10060] A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
```

**Notes**
- I tested this change in Python 2.7.10 and 3.4.3 with/without Squid proxy server.