### PR TITLE
Remove outdated comment about PyPy

### DIFF
--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -3,13 +3,6 @@
 # Proxies represent elements, their reference is stored in the C
 # structure of the respective node to avoid multiple instantiation of
 # the Python class.
-#
-# In PyPy, we store weak references instead of borrowed back-pointer
-# references as borrowed references cannot be long-lived in its
-# compatibility layer cpyext. Since we can't know when the object dies
-# (and even the weak-ref callback won't tell us that), we double check
-# on access that the object really is still alive and delete the
-# weak-ref if it isn't.
 
 @cython.linetrace(False)
 cdef inline _Element getProxy(xmlNode* c_node):


### PR DESCRIPTION
Sorry, my previous pull request left behind this comment at the start of the file.  This comment is now obsolete.