### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/doc/FAQ.txt
+++ b/doc/FAQ.txt
@@ -201,7 +201,7 @@ not take advantage of lxml's enhanced feature set.
   a secure HTTP proxy
 * `lwebstring <http://pypi.python.org/pypi/lwebstring>`_,
   an XML template engine
-* `openpyxl <https://openpyxl.readthedocs.org/>`_,
+* `openpyxl <https://openpyxl.readthedocs.io/>`_,
   a library to read/write MS Excel 2007 files
 * `OpenXMLlib <http://permalink.gmane.org/gmane.comp.python.lxml.devel/3250>`_,
   a library for handling OpenXML document meta data

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -23,7 +23,7 @@ Cython
 
 .. _pip: http://pypi.python.org/pypi/pip
 .. _Cython: http://cython.org
-.. _wheel: http://wheel.readthedocs.org/en/latest/
+.. _wheel: https://wheel.readthedocs.io/en/latest/
 
 The lxml.etree and lxml.objectify modules are written in Cython_.
 Since we distribute the Cython-generated .c files with lxml releases,


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.