### PR TITLE
fix typos

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -216,7 +216,7 @@ Source builds on MacOS-X
 If you are not using macports or want to use a more recent lxml
 release, you have to build it yourself.  While the pre-installed system
 libraries of libxml2 and libxslt are less outdated in recent MacOS-X
-versions than they used to be, so lxml should work them them out of the
+versions than they used to be, so lxml should work with them out of the
 box, it is still recommended to use a static build with the most recent
 library versions.
 

--- a/doc/build.txt
+++ b/doc/build.txt
@@ -321,7 +321,7 @@ Building Debian packages from SVN sources
   increase the debian version number so apt/dpkg won't get confused
 * run ``dpkg-buildpackage -rfakeroot -us -uc`` to build the package
 
-In case ``dpkg-buildpackage`` tells you that some dependecies are missing, you
+In case ``dpkg-buildpackage`` tells you that some dependencies are missing, you
 can either install them manually or run ``apt-get build-dep lxml``.
 
 That will give you .deb packages in the parent directory which can be

--- a/doc/extensions.txt
+++ b/doc/extensions.txt
@@ -277,7 +277,7 @@ and use the ``Extension`` helper:
   >>> print(e('l:function1(string(b))'))
   1Haegar
 
-The optional second argument to ``Extension`` can either be be a
+The optional second argument to ``Extension`` can either be a
 sequence of names to select from the module, a dictionary that
 explicitly maps function names to their XPath alter-ego or ``None``
 (explicitly passed) to take all available functions under their

--- a/doc/html5parser.txt
+++ b/doc/html5parser.txt
@@ -53,7 +53,7 @@ Function Reference
 ``fragment_fromstring(string, create_parent=False, guess_charset=False)``:
     Returns an HTML fragment from a string.  The fragment must contain
     just a single element, unless ``create_parent`` is given;
-    e.g,. ``fragment_fromstring(string, create_parent='div')`` will
+    e.g., ``fragment_fromstring(string, create_parent='div')`` will
     wrap the element in a ``<div>``.  If ``create_parent`` is true the
     default parent tag (div) is used.
 

--- a/doc/lxml-source-howto.txt
+++ b/doc/lxml-source-howto.txt
@@ -204,7 +204,7 @@ parser.pxi
     Parsers for XML and HTML.  This is the main parser engine.  It's
     the reason why you can parse a document from various sources in
     two lines of Python code.  It's definitely not the right place to
-    start reading lxml's soure code.
+    start reading lxml's source code.
 
 parsertarget.pxi
     An ElementTree compatible parser target implementation based on

--- a/doc/lxmlhtml.txt
+++ b/doc/lxmlhtml.txt
@@ -63,7 +63,7 @@ There are several functions available to parse HTML:
 ``fragment_fromstring(string, create_parent=False)``:
     Returns an HTML fragment from a string.  The fragment must contain
     just a single element, unless ``create_parent`` is given;
-    e.g,. ``fragment_fromstring(string, create_parent='div')`` will
+    e.g., ``fragment_fromstring(string, create_parent='div')`` will
     wrap the element in a ``<div>``.
 
 ``fragments_fromstring(string)``:

--- a/doc/memorymanagement.txt
+++ b/doc/memorymanagement.txt
@@ -31,7 +31,7 @@ This is the case when:
 
 This means that the whole tree in such a condition can be freed.
 
-Detecting whether a Node is in a tree thas has no Proxies connected to
+Detecting whether a Node is in a tree that has no Proxies connected to
 it can be done by relying on Python's garbage collection
 algorithm. Each Proxy can have a reference to the Proxy that points to
 the top of the tree. In case of a document tree, this reference is to

--- a/doc/performance.txt
+++ b/doc/performance.txt
@@ -665,7 +665,7 @@ Since then, lxml has matured a lot and has gotten much faster.  The iterparse
 variant now runs in 0.14 seconds, and if you remove the ``v.clear()``, it is
 even a little faster (which isn't the case for cElementTree).
 
-One of the many great tools in lxml is XPath, a swiss army knife for finding
+One of the many great tools in lxml is XPath, a Swiss army knife for finding
 things in XML documents.  It is possible to move the whole thing to a pure
 XPath implementation, which looks like this:
 

--- a/doc/s5/rst2s5.py
+++ b/doc/s5/rst2s5.py
@@ -60,7 +60,7 @@ from pygments import highlight
 from pygments.lexers import get_lexer_by_name, TextLexer
 
 class Pygments(Directive):
-    """ Source code syntax hightlighting.
+    """ Source code syntax highlighting.
     """
     required_arguments = 1
     optional_arguments = 0

--- a/doc/sax.txt
+++ b/doc/sax.txt
@@ -118,7 +118,7 @@ Interfacing with pulldom/minidom
 
 lxml.sax is a simple way to interface with the standard XML support in the
 Python library.  Note, however, that this is a one-way solution, as Python's
-DOM implementation connot generate SAX events from a DOM tree.
+DOM implementation cannot generate SAX events from a DOM tree.
 
 You can use xml.dom.pulldom to build a minidom from lxml:
 

--- a/doc/validation.txt
+++ b/doc/validation.txt
@@ -69,7 +69,7 @@ DTD from the parsed document using the ``docinfo`` property of the
 result ElementTree object.  The internal subset is available as
 ``internalDTD``, the external subset is provided as ``externalDTD``.
 
-The third way way to activate DTD loading is with the
+The third way to activate DTD loading is with the
 ``attribute_defaults`` option, which loads the DTD and weaves
 attribute default values into the document.  Again, no validation is
 performed unless explicitly requested.


### PR DESCRIPTION
These misspellings were found using [mwic](http://jwilk.net/software/mwic).