### PR TITLE
tutorial: Fix example to work with Python3

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -580,7 +580,7 @@ make sure only Element objects are returned, you can pass the
     >>> root.append(etree.Comment("some comment"))
 
     >>> for element in root.iter():
-    ...     if isinstance(element.tag, basestring):
+    ...     if hasattr(element.tag, 'startswith'):
     ...         print("%s - %s" % (element.tag, element.text))
     ...     else:
     ...         print("SPECIAL: %s - %s" % (element, element.text))


### PR DESCRIPTION
The builtin "basestring" type was removed in Python 3. As a consequence, this example’s code raises a NameError exception:

```
>>> for element in root.iter():
...     if isinstance(element.tag, basestring):
...         print("%s - %s" % (element.tag, element.text))
...     else:
...         print("SPECIAL: %s - %s" % (element, element.text))
```

This commit makes it work in both versions, by replacing the use of isinstance() with hasattr().