### PR TITLE
Add support for ucrt binaries on Windows

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -39,12 +39,12 @@ def download_and_extract_zlatkovic_binaries(destdir):
                     assert fn.endswith('.win32.zip')
                     libs[libname] = fn
     else:
-        url = "https://github.com/mhils/libxml2-win-binaries/releases/download/2016.06.27/"
+        url = "https://github.com/mhils/libxml2-win-binaries/releases/download/lxml/"
         libs = dict(
-            libxml2  = "libxml2-2.9.4.win32.zip",
-            libxslt  = "libxslt-1.1.27.win32.zip",
-            zlib     = "zlib-1.2.5.win32.zip",
-            iconv    = "iconv-1.14.win32.zip",
+            libxml2  = "libxml2-latest.win32.zip",
+            libxslt  = "libxslt-latest.win32.zip",
+            zlib     = "zlib-latest.win32.zip",
+            iconv    = "iconv-latest.win32.zip",
         )
 
     if not os.path.exists(destdir): os.makedirs(destdir)

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -24,19 +24,28 @@ except:
 # use pre-built libraries on Windows
 
 def download_and_extract_zlatkovic_binaries(destdir):
-    url = 'ftp://ftp.zlatkovic.com/pub/libxml/'
-    libs = dict(
-        libxml2  = None,
-        libxslt  = None,
-        zlib     = None,
-        iconv    = None,
-    )
-    for fn in ftp_listdir(url):
-        for libname in libs:
-            if fn.startswith(libname):
-                assert libs[libname] is None, 'duplicate listings?'
-                assert fn.endswith('.win32.zip')
-                libs[libname] = fn
+    if sys.version_info < (3, 5):
+        url = 'ftp://ftp.zlatkovic.com/pub/libxml/'
+        libs = dict(
+            libxml2  = None,
+            libxslt  = None,
+            zlib     = None,
+            iconv    = None,
+        )
+        for fn in ftp_listdir(url):
+            for libname in libs:
+                if fn.startswith(libname):
+                    assert libs[libname] is None, 'duplicate listings?'
+                    assert fn.endswith('.win32.zip')
+                    libs[libname] = fn
+    else:
+        url = "https://github.com/mhils/libxml2-win-binaries/releases/download/2016.06.27/"
+        libs = dict(
+            libxml2  = "libxml2-2.9.4.win32.zip",
+            libxslt  = "libxslt-1.1.27.win32.zip",
+            zlib     = "zlib-1.2.5.win32.zip",
+            iconv    = "iconv-1.14.win32.zip",
+        )
 
     if not os.path.exists(destdir): os.makedirs(destdir)
     for libname, libfn in libs.items():


### PR DESCRIPTION
Hi,

This PR is a first big step towards resolving [#1326096](https://bugs.launchpad.net/lxml/+bug/1326096). I went through the pain to recompile libiconv, libxml2 and libxslt with Visual Studio 2015/ucrt to have binaries that can be used to build a Python 3.5 wheel.

This PR makes sure that the ucrt binaries are downloaded when we are on Python 3.5. I documented the actual compilation of the binaries in a reproducible manner at https://github.com/mhils/libxml2-win-binaries. After merging this PR and installing the [Visual C++ Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) (or Visual Studio), a Python 3.5 x86 Windows wheel can be build as follows:

```
> "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
> python3 setup.py bdist_wheel --static-deps
```

I sucessfully tested [the resulting wheel](https://maximilianhils.com/upload/2016-06/lxml-3.6.0-cp35-cp35m-win32.whl) on a clean Win7 VM which worked fine. 

If I could ask for a favor, it would be great if you could upload a Python 3.5 Windows wheel to PyPi as soon as possible (feel free to take the wheel linked above or compile your own). We're currently migrating @mitmproxy to Python 3 and lxml is currently the only dependency that holds a `pip3 install mitmproxy` back.

Thanks!
Max