### PR TITLE
Ignore disabled form inputs

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -1010,7 +1010,7 @@ class FormElement(HtmlElement):
         results = []
         for el in self.inputs:
             name = el.name
-            if not name:
+            if not name or 'disabled' in el.attrib:
                 continue
             tag = _nons(el.tag)
             if tag == 'textarea':

--- a/src/lxml/html/tests/test_forms.txt
+++ b/src/lxml/html/tests/test_forms.txt
@@ -160,7 +160,7 @@ textarea_field: 'some text'
 >>> tree = lxml.html.fromstring('''
 ... <html><body>
 ...  <form>
-...   <input name="foo" value="bar"/>
+...   <input name="foo" value="bar" disabled/>
 ...   <input type="submit" />
 ...  </form>
 ... </body></html>
@@ -178,6 +178,8 @@ textarea_field: 'some text'
 >>> list(tree.forms[0].fields.values())
 ['bar']
 
+>>> ('foo', 'bar') not in tree.forms[0].form_values()
+True
 >>> tree = lxml.html.fromstring('''
 ... <html><body>
 ...  <form>


### PR DESCRIPTION
Disabled input elements are not in included in the emerging request in general according to [1](https://www.w3.org/TR/html5/forms.html#enabling-and-disabling-form-controls:-the-disabled-attribute) and [2](http://www.w3schools.com/tags/att_input_disabled.asp) which doesn't seems to be recognized by lxml yet.

These changes do not really implements the standard perfectly which includes also rules for which the disabled attribute would be invalid, but it's actually the way most browsers are handling it by disabling an input just when the disabled attribute is set at all independently of the actual value.