### PR TITLE
Fix setting the base url for etree.Resolver.resolve_string

### DIFF
--- a/src/lxml/includes/xmlparser.pxd
+++ b/src/lxml/includes/xmlparser.pxd
@@ -56,6 +56,7 @@ cdef extern from "libxml/tree.h":
         const_xmlChar* base
         const_xmlChar* cur
         const_xmlChar* end
+        const_char *filename
 
     ctypedef struct xmlParserInputBuffer:
         void* context

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -447,6 +447,8 @@ cdef xmlparser.xmlParserInput* _local_resolver(const_char* c_url, const_char* c_
             data = doc_ref._data_bytes
             c_input = xmlparser.xmlNewInputStream(c_context)
             if c_input is not NULL:
+                if doc_ref._filename:
+                    c_input.filename = <char *>tree.xmlStrdup(_xcstr(doc_ref._filename))
                 c_input.base = _xcstr(data)
                 c_input.length = python.PyBytes_GET_SIZE(data)
                 c_input.cur = c_input.base


### PR DESCRIPTION
See https://github.com/GNOME/libxml2/blob/master/parserInternals.c#L1549
We seem to get away with only setting the _filename so that relative
url's are resolved based on the value.

Fixes https://bugs.launchpad.net/lxml/+bug/1568167