### PR TITLE
Exclude `file` field `value` from `FormElement.form_values`.

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -1027,7 +1027,7 @@ class FormElement(HtmlElement):
                     "Unexpected tag: %r" % el)
                 if el.checkable and not el.checked:
                     continue
-                if el.type in ('submit', 'image', 'reset'):
+                if el.type in ('submit', 'image', 'reset', 'file'):
                     continue
                 value = el.value
                 if value is not None:

--- a/src/lxml/html/tests/test_forms.txt
+++ b/src/lxml/html/tests/test_forms.txt
@@ -28,6 +28,7 @@
 ...     <option value="3">number 3</option>
 ...     <option>number 4</option>
 ...   </select>
+...   <input type="file" name="file_field" value="nonsense_value">
 ...   <input type="submit" name="submit1" value="submit">
 ...   <input type="submit" name="submit2" value="submit">
 ...   <input type="reset" name="reset1">linksys
@@ -142,6 +143,7 @@ hidden_field=new+value&text_field=text_value&single_checkbox=on&single_checkbox2
 >>> for name, value in sorted(fields.items()):
 ...     print('%s: %r' % (name, value))
 check_group: <CheckboxValues {'1', '2', '3'} for checkboxes name='check_group'>
+file_field: 'nonsense_value'
 hidden_field: 'new value'
 radios: None
 reset1: None


### PR DESCRIPTION
Similar to `submit`, `image` and `reset`, browsers don't send `file` field values in the POST when form is submitted. `FormElement.form_values` method already correctly excluded `submit`, `image` and `reset` fields, now it also excludes the `file` fields.