### PR TITLE
Add .appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  matrix:
+    - python: 27
+    - python: 35
+#   - python: 35-x64
+
+install:
+  - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"
+  - python -m pip install -U pip wheel setuptools
+  - pip install -r requirements.txt
+
+build: false
+
+test_script:
+  - python -u setup.py clean
+  - python -u setup.py bdist_wheel --static-deps
+  - ps: Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }


### PR DESCRIPTION
This PR adds an AppVeyor configuration that auto-builds lxml wheels for Python 2.7 and 3.5 on Windows:
https://ci.appveyor.com/project/mhils/lxml/build/1.0.25

If you click on the individual jobs, you can go to the artifacts tab and download the wheels from AppVeyor. I tested both the Python 2.7 and 3.5 binaries and they all seem to work :smiley: