### PR TITLE
allow None as an attribute value, for HTML boolean attributes

### DIFF
--- a/doc/lxmlhtml.txt
+++ b/doc/lxmlhtml.txt
@@ -149,6 +149,12 @@ also include some extra methods:
     Returns a set-like object that allows accessing and modifying the
     names in the 'class' attribute of the element.  (New in lxml 3.5).
 
+``.set('attribute', None)``:
+    Creates a boolean attribute, like ``<form novalidate></form>``
+    or ``<div custom-attribute></div>``.  In XML attributes must
+    have at least the empty string as their value like ``<form
+    novalidate=""></form>``, but HTML boolean attributes can be either
+    present or absent from an element.
 
 Running HTML doctests
 =====================

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -564,11 +564,14 @@ cdef int _setAttributeValue(_Element element, key, value) except -1:
     if not element._doc._parser._for_html:
         _attributeValidOrRaise(tag)
     c_tag = _xcstr(tag)
-    if isinstance(value, QName):
-        value = _resolveQNameText(element, value)
+    if value is None:
+        c_value = NULL
     else:
-        value = _utf8(value)
-    c_value = _xcstr(value)
+        if isinstance(value, QName):
+            value = _resolveQNameText(element, value)
+        else:
+            value = _utf8(value)
+        c_value = _xcstr(value)
     if ns is None:
         c_ns = NULL
     else:

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -286,11 +286,17 @@ class ETreeOnlyTestCase(HelperTestCase):
 
     def test_attribute_set_invalid(self):
         # ElementTree accepts arbitrary attribute values
-        # lxml.etree allows only strings
+        # lxml.etree allows only strings, or None for (html5) boolean attributes
         Element = self.etree.Element
         root = Element("root")
         self.assertRaises(TypeError, root.set, "newattr", 5)
-        self.assertRaises(TypeError, root.set, "newattr", None)
+        self.assertRaises(TypeError, root.set, "newattr", object)
+
+    def test_attribute_set_none(self):
+        # lxml.etree allows None to represent (html5) boolean attributes
+        Element = self.etree.Element
+        root = Element("root")
+        root.set("boolean-attribute", None)
 
     def test_strip_attributes(self):
         XML = self.etree.XML

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -592,6 +592,13 @@ class HtmlParserTestCase(HelperTestCase):
         self.assertEqual(self.etree.tostring(doc),
                          _bytes('<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">\n<html/>'))
 
+    def test_boolean_attribute(self):
+        # ability to serialize boolean attribute by setting value to None
+        form = html.Element('form')
+        form.set('novalidate', None)
+        self.assertEqual(html.tostring(form), 
+                _bytes('<form novalidate></form>'))
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -599,6 +599,18 @@ class HtmlParserTestCase(HelperTestCase):
         self.assertEqual(html.tostring(form), 
                 _bytes('<form novalidate></form>'))
 
+    def test_boolean_attribute_round_trip(self):
+        # ability to pass boolean attributes unmodified
+        fragment = '<tag attribute></tag>'
+        self.assertEqual(html.tostring(html.fragment_fromstring(fragment)),
+                _bytes(fragment))
+
+    def test_boolean_attribute_xml_adds_empty_string(self):
+        # html serialized as xml converts boolean attributes to empty strings
+        fragment = '<tag attribute></tag>'
+        self.assertEqual(self.etree.tostring(html.fragment_fromstring(fragment)),
+                _bytes('<tag attribute=""/>'))
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
I was writing a script to convert some tags in Angular templates to a new API, and noticed that curiously lxml could parse and re-serialize boolean tags that have no value, but could not create new ones. It turns out libxml2 supports this by accepting NULL as the value for xmlSetNsProp(), creating an attribute node with NULL children instead of a text node.

This change allows None as a value for Element.set() so that those who value attributes with no value can create the same.

Note that lxml.etree.tostring() serializes these as `<form novalidate=''></form>` while lxml.html.tostring() produces the value in the test.