### PR TITLE
manylinux: Add build-wheels.sh and wheel_manylinux target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ PY3_WITH_CYTHON=$(shell $(PYTHON3) -c 'import Cython.Build.Dependencies' >/dev/n
 CYTHON_WITH_COVERAGE=$(shell $(PYTHON) -c 'import Cython.Coverage; import sys; assert not hasattr(sys, "pypy_version_info")' >/dev/null 2>/dev/null && echo " --coverage" || true)
 CYTHON3_WITH_COVERAGE=$(shell $(PYTHON3) -c 'import Cython.Coverage; import sys; assert not hasattr(sys, "pypy_version_info")' >/dev/null 2>/dev/null && echo " --coverage" || true)
 
+MANYLINUX_IMAGE_X86_64=quay.io/pypa/manylinux1_x86_64
+
 all: inplace
 
 # Build in-place
@@ -21,6 +23,12 @@ sdist:
 
 build:
 	$(PYTHON) setup.py $(SETUPFLAGS) build $(PYTHON_WITH_CYTHON)
+
+wheel_manylinux:
+	docker run --rm -t \
+		-v $(shell pwd):/io \
+		$(MANYLINUX_IMAGE_X86_64) \
+		bash /io/tools/manylinux/build-wheels.sh
 
 wheel:
 	$(PYTHON) setup.py $(SETUPFLAGS) bdist_wheel $(PYTHON_WITH_CYTHON)

--- a/tools/manylinux/build-wheels.sh
+++ b/tools/manylinux/build-wheels.sh
@@ -1,0 +1,61 @@
+#/!/bin/bash
+#
+# Called inside the manylinux image
+echo "Started $0 $@"
+
+set -e -x
+REQUIREMENTS=/io/requirements.txt
+WHEELHOUSE=/io/wheelhouse
+
+build_wheel() {
+    env STATIC_DEPS=true \
+        LDFLAGS="$LDFLAGS -fPIC" \
+        CFLAGS="$CFLAGS -fPIC" \
+        ${PYBIN}/pip \
+            wheel \
+            /io \
+            -w $WHEELHOUSE
+}
+
+assert_importable() {
+    # Install packages and test
+    for PYBIN in /opt/python/*/bin/; do
+        ${PYBIN}/pip install lxml --no-index -f $WHEELHOUSE
+
+        (cd $HOME; ${PYBIN}/python -c 'import lxml')
+    done
+}
+
+prepare_system() {
+    yum install -y zlib-devel
+    # Remove Python 2.6 symlinks
+    rm /opt/python/cp26*
+}
+
+build_wheels() {
+    # Compile wheels for all python versions
+    for PYBIN in /opt/python/*/bin; do
+        # Install requirements if file exists
+        test ! -e $REQUIREMENTS \
+            || ${PYBIN}/pip install -r $REQUIREMENTS
+
+        build_wheel
+    done
+}
+
+repair_wheels() {
+    # Bundle external shared libraries into the wheels
+    for whl in $WHEELHOUSE/*.whl; do
+        auditwheel repair $whl -w $WHEELHOUSE
+    done
+}
+
+show_wheels() {
+    ls -l $WHEELHOUSE
+}
+
+prepare_system
+build_wheels
+repair_wheels
+assert_importable
+show_wheels


### PR DESCRIPTION
The `wheel_manylinux` Makefile target starts [pypa's manylinux_x86_64 image](https://github.com/pypa/manylinux) and runs `tools/manylinux/build-wheels.sh` inside it.

`tools/manylinux/build-wheels.sh` iterates over the manylinux system's python installations and builds a wheel for each of them, the wheels are then put in `/io/wheelhouse`, where `/io` is the mounted git root of lxml.

- The wheel builds are static for now.
-  No wheels are built for Python 2.6 or 32-bit x86.