### PR TITLE
link with "-lrt" error on darwin (OS X)

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -238,6 +238,8 @@ def libraries():
         libs.extend(['zlib', 'WS2_32'])
     elif OPTION_STATIC:
         libs = ['rt', 'z', 'm']
+    elif sys.platform in ('darwin',):
+        libs = ['xslt', 'exslt', 'xml2', 'z', 'm']
     else:
         libs = ['xslt', 'exslt', 'rt', 'xml2', 'z', 'm']
     return libs


### PR DESCRIPTION
add -lt link will failed on Darwin (OS X 10.11)