### PR TITLE
Fix xslt error parsing so filename and line numbers show.

### DIFF
--- a/src/lxml/xmlerror.pxi
+++ b/src/lxml/xmlerror.pxi
@@ -643,10 +643,10 @@ cdef void _receiveXSLTError(void* c_log_handler, char* msg, ...) nogil:
                 if c_pos == msg + 1:
                     c_text = c_str  # msg == "%s..."
                 elif c_name_pos[0] == b'e':
-                    if cstring_h.strncmp(c_name_pos, 'element %s', 10):
+                    if cstring_h.strncmp(c_name_pos, 'element %s', 10) == 0:
                         c_element = c_str
                 elif c_name_pos[0] == b'f':
-                    if cstring_h.strncmp(c_name_pos, 'file %s', 7):
+                    if cstring_h.strncmp(c_name_pos, 'file %s', 7) == 0:
                         if cstring_h.strncmp('string://__STRING__XSLT',
                                              c_str, 23) == 0:
                             c_str = '<xslt>'
@@ -654,7 +654,7 @@ cdef void _receiveXSLTError(void* c_log_handler, char* msg, ...) nogil:
             elif c_pos[0] == b'd':  # "%d"
                 format_count += 1
                 c_int = cvarargs.va_int(args)
-                if cstring_h.strncmp(c_name_pos, 'line %d', 7):
+                if cstring_h.strncmp(c_name_pos, 'line %d', 7) == 0:
                     c_error.line = c_int
             elif c_pos[0] != b'%':  # "%%" == "%"
                 format_count += 1


### PR DESCRIPTION
This is worth a :facepalm: ...

Before:

```
<string>:0:0:ERROR:XSLT:ERR_OK: compilation error, element 'foo'
<string>:0:0:ERROR:XSLT:ERR_OK: xsltStylePreCompute: unknown xsl:foo
<string>:0:0:ERROR:XSLT:ERR_OK: compilation error, element 'foo'
<string>:0:0:ERROR:XSLT:ERR_OK: xsltParseStylesheetTop: unknown foo element
```

After:

``` nohighlight
errtest.xml:3:0:ERROR:XSLT:ERR_OK: compilation error, element 'foo'
<string>:0:0:ERROR:XSLT:ERR_OK: xsltStylePreCompute: unknown xsl:foo
errtest.xml:3:0:ERROR:XSLT:ERR_OK: compilation error, element 'foo'
<string>:0:0:ERROR:XSLT:ERR_OK: xsltParseStylesheetTop: unknown foo element
```

We can't do better, as the second line in the two errors embellishes the first line and does not duplicate the file/line info.

Example:

``` python
from io import BytesIO
from lxml import etree
style = etree.parse("errtest.xml")
try:
    etree.XSLT(style)
except etree.XSLTParseError as e:
    print e.error_log
```