### PR TITLE
AppVeyor: Build Python 3.5 x64 wheels for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
     - python: 27
     - python: 35
-#   - python: 35-x64
+    - python: 35-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -40,12 +40,16 @@ def download_and_extract_zlatkovic_binaries(destdir):
                     assert fn.endswith('.win32.zip')
                     libs[libname] = fn
     else:
+        if sys.maxsize > 2147483647:
+            arch = "win64"
+        else:
+            arch = "win32"
         url = "https://github.com/mhils/libxml2-win-binaries/releases/download/lxml/"
         libs = dict(
-            libxml2  = "libxml2-latest.win32.zip",
-            libxslt  = "libxslt-latest.win32.zip",
-            zlib     = "zlib-latest.win32.zip",
-            iconv    = "iconv-latest.win32.zip",
+            libxml2  = "libxml2-latest.{}.zip".format(arch),
+            libxslt  = "libxslt-latest.{}.zip".format(arch),
+            zlib     = "zlib-latest.{}.zip".format(arch),
+            iconv    = "iconv-latest.{}.zip".format(arch),
         )
 
     if not os.path.exists(destdir): os.makedirs(destdir)


### PR DESCRIPTION
This PR enables the Python35-x64 target so that AppVeyor automatically generates 64 bit wheels for lxml. For example, [here](https://ci.appveyor.com/project/mhils/lxml) is the latest AppVeyor build for `mhils/lxml`, and [here](https://ci.appveyor.com/project/mhils/lxml/build/1.0.27/job/mr1qr4tgv0cyoe4w/artifacts) is the corresponding x64 wheel produced by AppVeyor.

These builds are now possible because I upgraded https://github.com/mhils/libxml2-win-binaries to also produce 64 bit binaries. It would be nice to finally see Python 3.5 Windows wheels on PyPI - if there's anything else I can do to make that happen, please let me know. All that needs to be done is 

1. Enabling AppVeyor for `lxml/lxml`
2. Changing the configuration filename in AppVeyor to `.appveyor.yml` (not `appveyor.yml`)
3. Uploading the resulting artifacts to PyPI.

The Python 2.7 wheel builder fails currently, but that is caused by https://bugs.python.org/issue27973 and will hopefully be fixed with the next 2.7 patch release.

Thanks!
Max