### PR TITLE
Make it possible to temporarily override output method when calling _IncrementalWriter.write

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -937,12 +937,19 @@ cdef class _IncrementalFileWriter:
                     flat_namespaces_map[ns] = prefix
         return flat_namespaces_map, new_namespaces
 
-    def write(self, *args, bint with_tail=True, bint pretty_print=False):
-        """write(self, *args, with_tail=True, pretty_print=False)
+    def write(self, *args, bint with_tail=True, bint pretty_print=False,
+                                                                   method=None):
+        """write(self, *args, with_tail=True, pretty_print=False, method=None)
 
         Write subtrees or strings into the file.
         """
         assert self._c_out is not NULL
+
+        if method is None:
+            method_c = self._method
+        else:
+            method_c = _findOutputMethod(method)
+
         for content in args:
             if _isString(content):
                 if self._status != WRITER_IN_ELEMENT:
@@ -954,7 +961,7 @@ cdef class _IncrementalFileWriter:
                 if self._status > WRITER_IN_ELEMENT:
                     raise LxmlSyntaxError("cannot append trailing element to complete XML document")
                 _writeNodeToBuffer(self._c_out, (<_Element>content)._c_node,
-                                   self._c_encoding, NULL, self._method,
+                                   self._c_encoding, NULL, method_c,
                                    False, False, pretty_print, with_tail, False)
                 if (<_Element>content)._c_node.type == tree.XML_ELEMENT_NODE:
                     if not self._element_stack:

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -941,8 +941,11 @@ cdef class _IncrementalFileWriter:
                                                                    method=None):
         """write(self, *args, with_tail=True, pretty_print=False, method=None)
 
-        Write subtrees or strings into the file.
+        Write subtrees or strings into the file. If method is not None, it
+        should be one of ('html', 'xml') to temporarily override the output
+        method.
         """
+
         assert self._c_out is not NULL
 
         if method is None:

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -401,6 +401,23 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
             '</root>')
         self._file = BytesIO()
 
+    def test_xml_mode_element_inside_html(self):
+        # The htmlfile already outputs in xml mode for .element calls. This
+        # test actually illustrates a bug
+
+        with etree.htmlfile(self._file) as xf:
+            with xf.element("root"):
+                with xf.element('foo', attrib={'selected': 'bar'}):
+                    pass
+
+        self.assertXml(
+            '<root>'
+              # '<foo selected></foo>'  # FIXME: this is the correct output
+                                        # in html mode
+              '<foo selected="bar"></foo>'
+            '</root>')
+        self._file = BytesIO()
+
     def test_write_declaration(self):
         with etree.htmlfile(self._file) as xf:
             try:

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -380,6 +380,27 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
             self.assertXml('<%s>' % tag)
             self._file = BytesIO()
 
+    def test_xml_mode_write_inside_html(self):
+        elt = etree.Element("foo", attrib={'selected': 'bar'})
+
+        with etree.htmlfile(self._file) as xf:
+            with xf.element("root"):
+                xf.write(elt)  # 1
+
+                assert elt.text is None
+                xf.write(elt, method='xml')  # 2
+
+                elt.text = ""
+                xf.write(elt, method='xml')  # 3
+
+        self.assertXml(
+            '<root>'
+                '<foo selected></foo>'  # 1
+                '<foo selected="bar"/>'  # 2
+                '<foo selected="bar"></foo>'  # 3
+            '</root>')
+        self._file = BytesIO()
+
     def test_write_declaration(self):
         with etree.htmlfile(self._file) as xf:
             try:


### PR DESCRIPTION
Behold:

```
>>> from lxml import html, etree
>>> from lxml.builder import E
>>> html.tostring(E.foo(selected="bar"))
'<foo selected></foo>'
>>> etree.tostring(E.foo(selected="bar"))
'<foo selected="bar"/>'
```

With custom elements, HTML is no more a tag soup of predefined tag names. As can be seen in: https://user-content-dot-custom-elements.appspot.com/PolymerElements/paper-dropdown-menu/v1.4.2/paper-dropdown-menu/demo/index.html we may need to have the value of the ``selected`` attribute.

My solution to this is the ability to override the output method temporarily in write calls.

Stefan, If the patch is as simple as this, could you advise about the actual value to pass to write() when overriding method?

Thanks & best regards