### PR TITLE
Tutorial: Import BytesIO and mark text as bytes

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -822,7 +822,8 @@ doing this all together and use the string parsing functions above.
 
 .. sourcecode:: pycon
 
-    >>> some_file_like_object = BytesIO("<root>data</root>")
+    >>> from io import BytesIO
+    >>> some_file_like_object = BytesIO(b"<root>data</root>")
 
     >>> tree = etree.parse(some_file_like_object)
 


### PR DESCRIPTION
For python 3 fixes:
* NameError: name 'BytesIO' is not defined
* TypeError: a bytes-like object is required, not 'str'