### PR TITLE
expose collect_ids for HTMLParser as well

### DIFF
--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1596,7 +1596,7 @@ cdef class HTMLParser(_FeedParser):
     u"""HTMLParser(self, encoding=None, remove_blank_text=False, \
                    remove_comments=False, remove_pis=False, strip_cdata=True, \
                    no_network=True, target=None, schema: XMLSchema =None, \
-                   recover=True, compact=True)
+                   recover=True, compact=True, collect_ids=True)
 
     The HTML parser.
 
@@ -1615,6 +1615,7 @@ cdef class HTMLParser(_FeedParser):
     - strip_cdata        - replace CDATA sections by normal text content (default: True)
     - compact            - save memory for short text content (default: True)
     - default_doctype    - add a default doctype even if it is not found in the HTML (default: True)
+    - collect_ids        - Set this to False to avoid ever-growing id cache to make ID lookups work.
 
     Other keyword arguments:
 
@@ -1628,7 +1629,8 @@ cdef class HTMLParser(_FeedParser):
     def __init__(self, *, encoding=None, remove_blank_text=False,
                  remove_comments=False, remove_pis=False, strip_cdata=True,
                  no_network=True, target=None, XMLSchema schema=None,
-                 recover=True, compact=True, default_doctype=True):
+                 recover=True, compact=True, default_doctype=True,
+                 collect_ids=True):
         cdef int parse_options
         parse_options = _HTML_DEFAULT_PARSE_OPTIONS
         if remove_blank_text:
@@ -1643,8 +1645,8 @@ cdef class HTMLParser(_FeedParser):
             parse_options = parse_options ^ htmlparser.HTML_PARSE_NODEFDTD
 
         _BaseParser.__init__(self, parse_options, 1, schema,
-                             remove_comments, remove_pis, strip_cdata, True,
-                             target, encoding)
+                             remove_comments, remove_pis, strip_cdata,
+                             collect_ids, target, encoding)
 
 
 cdef HTMLParser __DEFAULT_HTML_PARSER


### PR DESCRIPTION
It's said to lower the memory footprint of the parser at the expense of increased CPU load. Some use cases might care more about the amount memory consumed than CPU time, so it might make sense to expose this parameter.