### PR TITLE
Make XMLSyntaxError have normal SyntaxError metadata

### DIFF
--- a/src/lxml/tests/test_errors.py
+++ b/src/lxml/tests/test_errors.py
@@ -49,6 +49,24 @@ class ErrorTestCase(HelperTestCase):
         finally:
             sys.settrace(trace_func)
 
+    def test_xmlsyntaxerror_has_info(self):
+        broken_xml_name = 'test_broken.xml'
+        broken_xml_path = os.path.join(this_dir, broken_xml_name)
+        fail_msg = 'test_broken.xml should raise an etree.XMLSyntaxError'
+        try:
+            etree.parse(broken_xml_path)
+        except etree.XMLSyntaxError as e:
+            # invariant
+            self.assertEqual(e.position, (e.lineno, e.offset + 1), 'position and lineno/offset out of sync')
+            # SyntaxError info derived from file & contents
+            self.assertTrue(e.filename.endswith(broken_xml_name), 'filename must be preserved')
+            self.assertEqual(e.lineno, 1)
+            self.assertEqual(e.offset, 10)
+        except Exception as e:
+            self.fail('{}, not {}'.format(fail_msg, type(e)))
+        else:
+            self.fail('test_broken.xml should raise an etree.XMLSyntaxError')
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/xmlerror.pxi
+++ b/src/lxml/xmlerror.pxi
@@ -231,12 +231,13 @@ cdef class _BaseErrorLog:
             message = default_message
         line = self._first_error.line
         column = self._first_error.column
+        filename = self._first_error.filename
         if line > 0:
             if column > 0:
                 message = u"%s, line %d, column %d" % (message, line, column)
             else:
                 message = u"%s, line %d" % (message, line)
-        return exctype(message, code, line, column)
+        return exctype(message, code, line, column, filename)
 
     @cython.final
     cdef _buildExceptionMessage(self, default_message):


### PR DESCRIPTION
Some tools (e.g. IPython) [show a special error message](https://github.com/ipython/ipython/blob/7bd2ff815dde32552b9c55ebbad8de83366aea46/IPython/core/ultratb.py#L704-L735) like the following if common `SyntaxError` metadata is available:

```pytb
$ PYTHONPATH=src ipython
In [1]: from lxml import etree
In [2]: etree.parse('src/lxml/tests/test_broken.xml')
  File "src/lxml/tests/test_broken.xml", line 1
    <a><b></c></b></a>
             ^
XMLSyntaxError: Opening and ending tag mismatch: b line 1 and c, line 1, column 11
```

This PR adds the necessary fields `filename`, `lineno` and `offset`, while making `position` a property in order to keep it in sync with `lineno` and `offset` if those are changed.