### PR TITLE
Fix <script> and <style> text content serialization

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -954,7 +954,14 @@ cdef class _IncrementalFileWriter:
                     if self._status > WRITER_IN_ELEMENT or content.strip():
                         raise LxmlSyntaxError("not in an element")
                 content = _utf8(content)
-                tree.xmlOutputBufferWriteEscape(self._c_out, _xcstr(content), NULL)
+
+                ns, name, _, _ = self._element_stack[-1]
+                if c_method == OUTPUT_METHOD_HTML and \
+                        ns in (None, 'http://www.w3.org/1999/xhtml') and name in ('script', 'style'):
+                    tree.xmlOutputBufferWrite(self._c_out, len(content), content)
+                else:
+                    tree.xmlOutputBufferWriteEscape(self._c_out, _xcstr(content), NULL)
+
             elif iselement(content):
                 if self._status > WRITER_IN_ELEMENT:
                     raise LxmlSyntaxError("cannot append trailing element to complete XML document")

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -418,6 +418,20 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
             '</root>')
         self._file = BytesIO()
 
+    def test_unescaped_script(self):
+        with etree.htmlfile(self._file) as xf:
+            elt = etree.Element('script')
+            elt.text = "if (a < b);"
+            xf.write(elt)
+        self.assertXml('<script>if (a < b);</script>')
+
+    def test_unescaped_script_incremental(self):
+        with etree.htmlfile(self._file) as xf:
+            with xf.element('script'):
+                xf.write("if (a < b);")
+
+        self.assertXml('<script>if (a < b);</script>')
+
     def test_write_declaration(self):
         with etree.htmlfile(self._file) as xf:
             try:


### PR DESCRIPTION
Behold:

```
>>> from six import BytesIO
>>> from lxml import etree
>>> f = BytesIO()
>>> with etree.htmlfile(f) as xf:
...     elt = etree.Element('script')
...     elt.text = "if (a < b);"
...     xf.write(elt)
...
>>> f.getvalue()
'<script>if (a < b);</script>'
```

... which is correct.

However:

```
>>> f = BytesIO()
>>> with etree.htmlfile(f) as xf:
...     with xf.element('script'):
...         xf.write("if (a < b);")
...
>>> f.getvalue()
'<script>if (a &lt; b);</script>'
```

... which is not only incorrect, but also quite annoying :)

This patch is an attempt at fixing it.