### PR TITLE
Fix attribute misquoting

### DIFF
--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -358,7 +358,7 @@ cdef extern from "libxml/tree.h":
                                 xmlDoc* doc, xmlNode* cur, int level,
                                 int format, const_char* encoding) nogil
     cdef void xmlBufAttrSerializeTxtContent(xmlOutputBuffer *buf, xmlDoc *doc,
-                                xmlAttr *attr, const xmlChar *string) nogil
+                                xmlAttr *attr, const_xmlChar *string) nogil
     cdef void xmlNodeSetName(xmlNode* cur, const_xmlChar* name) nogil
     cdef void xmlNodeSetContent(xmlNode* cur, const_xmlChar* content) nogil
     cdef xmlDtd* xmlCopyDtd(xmlDtd* dtd) nogil

--- a/src/lxml/includes/tree.pxd
+++ b/src/lxml/includes/tree.pxd
@@ -357,6 +357,8 @@ cdef extern from "libxml/tree.h":
     cdef void xmlNodeDumpOutput(xmlOutputBuffer* buf,
                                 xmlDoc* doc, xmlNode* cur, int level,
                                 int format, const_char* encoding) nogil
+    cdef void xmlBufAttrSerializeTxtContent(xmlOutputBuffer *buf, xmlDoc *doc,
+                                xmlAttr *attr, const xmlChar *string) nogil
     cdef void xmlNodeSetName(xmlNode* cur, const_xmlChar* name) nogil
     cdef void xmlNodeSetContent(xmlNode* cur, const_xmlChar* content) nogil
     cdef xmlDtd* xmlCopyDtd(xmlDtd* dtd) nogil

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -883,7 +883,7 @@ cdef class _IncrementalFileWriter:
             tree.xmlOutputBufferWrite(self._c_out, 1, ' ')
             self._write_qname(name, prefix)
             tree.xmlOutputBufferWrite(self._c_out, 2, '="')
-            tree.xmlOutputBufferWriteEscape(self._c_out, _xcstr(value), NULL)
+            tree.xmlBufAttrSerializeTxtContent(self._c_out, NULL, NULL, _xcstr(value))
             tree.xmlOutputBufferWrite(self._c_out, 1, '"')
 
     cdef _write_end_element(self, element_config):

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -418,6 +418,13 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
             '</root>')
         self._file = BytesIO()
 
+    def test_attribute_quoting(self):
+        with etree.htmlfile(self._file) as xf:
+            with xf.element("tagname", attrib={"attr": '"misquoted"'}):
+                xf.write("foo")
+
+        self.assertXml('<tagname attr="&quot;misquoted&quot;">foo</tagname>')
+
     def test_unescaped_script(self):
         with etree.htmlfile(self._file) as xf:
             elt = etree.Element('script')


### PR DESCRIPTION
Behold:

```
>>> from lxml import html
>>> from lxml.etree import htmlfile
>>> from lxml.html.builder import E
>>> from StringIO import StringIO
>>> out = StringIO()
>>> with htmlfile(out) as f:
... with f.element("tagname", attrib={"attr": '"misquoted"'}):
... f.write("foo")
...
>>> out.getvalue()
'<tagname attr=""misquoted"">foo</tagname>'
```



Expected output:

```
'<tagname attr="&quot;misquoted&quot;">foo</tagname>'
```

https://bugs.launchpad.net/lxml/+bug/1594155

Not fixed yet but we're closer than we were yesterday :)