### PR TITLE
Fix the form submission example

### DIFF
--- a/doc/lxmlhtml.txt
+++ b/doc/lxmlhtml.txt
@@ -477,8 +477,8 @@ Example:
 
     >>> from lxml.html import parse, submit_form
     >>> page = parse('http://tinyurl.com').getroot()
-    >>> page.forms[1].fields['url'] = 'http://lxml.de/'
-    >>> result = parse(submit_form(page.forms[1])).getroot()
+    >>> page.forms[0].fields['url'] = 'http://lxml.de/'
+    >>> result = parse(submit_form(page.forms[0])).getroot()
     >>> [a.attrib['href'] for a in result.xpath("//a[@target='_blank']")]
     ['http://tinyurl.com/2xae8s', 'http://preview.tinyurl.com/2xae8s']
 


### PR DESCRIPTION
Fixes:
```pycon
>>> page = parse('http://tinyurl.com').getroot()
>>> page.forms[1].fields['url'] = 'http://lxml.de/'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../lxml/html/__init__.py", line 1150, in __setitem__
    self.inputs[item].value = value
  File ".../lxml/html/__init__.py", line 1216, in __getitem__
    "No input element with the name %r" % name)
KeyError: "No input element with the name 'url'"
```