### PR TITLE
Fix POST form submission for Python 3

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -1137,6 +1137,8 @@ def open_http_urllib(method, url, values):
         data = None
     else:
         data = urlencode(values)
+        if not isinstance(data, bytes):
+            data = data.encode('ASCII')
     return urlopen(url, data)
 
 


### PR DESCRIPTION
In Python 3, `urlencode()` returns Unicode string; but `urlopen()` wants only bytes in data, so it need to be encoded first.

Fixes:
```pycon
>>> form = lxml.html.fromstring('<form method="POST">', base_url='http://localhost')
>>> lxml.html.submit_form(form)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../lxml/html/__init__.py", line 1119, in submit_form
    return open_http(form.method, url, values)
  File ".../lxml/html/__init__.py", line 1140, in open_http_urllib
    return urlopen(url, data)
  File ".../urllib/request.py", line 163, in urlopen
    return opener.open(url, data, timeout)
  File ".../urllib/request.py", line 464, in open
    req = meth(req)
  File ".../urllib/request.py", line 1183, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes or an iterable of bytes. It cannot be of type str.
```