### PR TITLE
Fix AppVeyor builds for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ install:
 
       python -m pip install -U pip wheel setuptools
 
-      pip install -r requirements.txt
+      pip install -r requirements.txt --install-option="--no-cython-compile"
 
 build_script:
   - cmd: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,12 +11,15 @@ environment:
 install:
   - cmd: >-
       SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%
+
       python -m pip install -U pip wheel setuptools
+
       pip install -r requirements.txt
 
 build_script:
   - cmd: >-
       python -u setup.py clean
+
       python -u setup.py bdist_wheel --static-deps
 
 test_script:

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -57,6 +57,7 @@ def download_and_extract_zlatkovic_binaries(destdir):
         srcfile = urljoin(url, libfn)
         destfile = os.path.join(destdir, libfn)
         print('Retrieving "%s" to "%s"' % (srcfile, destfile))
+        urlcleanup()  # work around FTP bug 27973 in Py2.7.12+
         urlretrieve(srcfile, destfile)
         d = unpack_zipfile(destfile, destdir)
         libs[libname] = d


### PR DESCRIPTION
This fixes two build-breaking issues and adds an optimisation:
* Corrupted .appveyor.yml was causing the wrong commands to be run, failing to run `pip install`
* Python 2.7.12+ FTP download bugfix wasn't applied to the code downloading the win32 pre-build libs
* Cython doesn't currently have wheels for Python 3.6, so was adding 30-50% of the build time generating local wheels, while downloading existing wheels saves only 8-10%.