### PR TITLE
Skip TempPathXmlFileTestCase for the incremental XML API

### DIFF
--- a/src/lxml/tests/common_imports.py
+++ b/src/lxml/tests/common_imports.py
@@ -175,12 +175,16 @@ else:
 try:
     skipIf = unittest.skipIf
 except AttributeError:
-    def skipIf(condition, why,
-               _skip=lambda test_method: None,
-               _keep=lambda test_method: test_method):
+    def skipIf(condition, why):
+        def _skip(thing):
+            import types
+            if isinstance(thing, (type, types.ClassType)):
+                return type(thing.__name__, (object,), {})
+            else:
+                return None
         if condition:
             return _skip
-        return _keep
+        return lambda thing: thing
 
 
 class HelperTestCase(unittest.TestCase):

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -286,6 +286,7 @@ class TempXmlFileTestCase(_XmlFileTestCaseBase):
         self._file = tempfile.TemporaryFile()
 
 
+@skipIf(sys.platform.startswith("win"), "Can't reopen temporary files on Windows")
 class TempPathXmlFileTestCase(_XmlFileTestCaseBase):
     def setUp(self):
         self._tmpfile = tempfile.NamedTemporaryFile()


### PR DESCRIPTION
On "Windows NT or later", you cannot reopen a file created by
`tempfile.NamedTemporaryFile` while the file-like object is still
active.

See
https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile