### PR TITLE
Enable caching of libraries in build step

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -56,9 +56,12 @@ def download_and_extract_zlatkovic_binaries(destdir):
     for libname, libfn in libs.items():
         srcfile = urljoin(url, libfn)
         destfile = os.path.join(destdir, libfn)
-        print('Retrieving "%s" to "%s"' % (srcfile, destfile))
-        urlcleanup()  # work around FTP bug 27973 in Py2.7.12+
-        urlretrieve(srcfile, destfile)
+        if os.path.exists(destfile + ".keep"):
+            print('Using local copy of  "{}"'.format(srcfile))
+        else:
+            print('Retrieving "%s" to "%s"' % (srcfile, destfile))
+            urlcleanup()  # work around FTP bug 27973 in Py2.7.12+
+            urlretrieve(srcfile, destfile)
         d = unpack_zipfile(destfile, destdir)
         libs[libname] = d
 


### PR DESCRIPTION
This PR makes it possible to experiment with local copies of the Windows dependencies instead of downloading them all the time. As the existence of a file does not imply that it is at the latest version, dependencies are only cached if a corresponding ".keep" file exists. For example, the local copy of `iconv-latest.win32.zip` is only taken if `iconv-latest.win32.zip.keep` exists.

This is motivated by https://github.com/mhils/libxml2-win-binaries/pull/7#issuecomment-279222114 and would allow for an easy testing of compiled binaries on appveyor.