### PR TITLE
Add Python 2.6 to the AppVeyor build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,6 +2,7 @@ version: 1.0.{build}
 
 environment:
   matrix:
+  - python: 26
   - python: 27
   - python: 35
   - python: 35-x64
@@ -10,7 +11,7 @@ environment:
 
 install:
     - SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%
-    - python -m pip install -U pip wheel setuptools
+    - python -m pip.__main__ install -U pip wheel setuptools
     - pip install -r requirements.txt --install-option="--no-cython-compile"
 
 build: off


### PR DESCRIPTION
Python 2.6 can't run pip with "python -m", and since we're not doing
that on the next line anyway, clearly that's not needed since we have
the right Python\scripts folder in our path.