### PR TITLE
Add check for c_src_dict in _fixThreadDictPtr

### DIFF
--- a/src/lxml/proxy.pxi
+++ b/src/lxml/proxy.pxi
@@ -460,7 +460,7 @@ cdef inline void _fixThreadDictPtr(const_xmlChar** c_ptr,
                                    tree.xmlDict* c_src_dict,
                                    tree.xmlDict* c_dict) nogil:
     c_str = c_ptr[0]
-    if c_str and tree.xmlDictOwns(c_src_dict, c_str):
+    if c_str and c_src_dict and tree.xmlDictOwns(c_src_dict, c_str):
         # return value can be NULL on memory error, but we don't handle that here
         c_str = tree.xmlDictLookup(c_dict, c_str, -1)
         if c_str:


### PR DESCRIPTION
If a document is created outside of LXML and converted to an LXML node with elementFactory, its dictionary might be NULL, which would make xmlDictOwns return -1, which counts as true. If the nodes in that document are then moved to an LXML document, fixThreadDictNsForNode would then set the href and prefix pointers to point to the dictionary, which would cause a bad free when the document gets freed.