### PR TITLE
Adds a `smart_prefix` option to XPath evaluations to overcome a counter-intuitive design flaw

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -1566,14 +1566,15 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
         return _elementpath.iterfind(self, path, namespaces)
 
     def xpath(self, _path, *, namespaces=None, extensions=None,
-              smart_strings=True, **_variables):
+              smart_strings=True, smart_prefix=False, **_variables):
         u"""xpath(self, _path, namespaces=None, extensions=None, smart_strings=True, **_variables)
 
         Evaluate an xpath expression using the element as context node.
         """
         evaluator = XPathElementEvaluator(self, namespaces=namespaces,
                                           extensions=extensions,
-                                          smart_strings=smart_strings)
+                                          smart_strings=smart_strings,
+                                          smart_prefix=smart_prefix)
         return evaluator(_path, **_variables)
 
     def cssselect(self, expr, *, translator='xml'):
@@ -2253,7 +2254,7 @@ cdef public class _ElementTree [ type LxmlElementTreeType,
         return root.iterfind(path, namespaces)
 
     def xpath(self, _path, *, namespaces=None, extensions=None,
-              smart_strings=True, **_variables):
+              smart_strings=True, smart_prefix=False, **_variables):
         u"""xpath(self, _path, namespaces=None, extensions=None, smart_strings=True, **_variables)
 
         XPath evaluate in context of document.
@@ -2274,7 +2275,8 @@ cdef public class _ElementTree [ type LxmlElementTreeType,
         self._assertHasRoot()
         evaluator = XPathDocumentEvaluator(self, namespaces=namespaces,
                                            extensions=extensions,
-                                           smart_strings=smart_strings)
+                                           smart_strings=smart_strings,
+                                           smart_prefix=smart_prefix)
         return evaluator(_path, **_variables)
 
     def xslt(self, _xslt, extensions=None, access_control=None, **_kw):

--- a/src/lxml/extensions.pxi
+++ b/src/lxml/extensions.pxi
@@ -243,11 +243,11 @@ cdef class _BaseContext:
                 xpath.xmlXPathRegisterNs(self._xpathCtxt,
                                          _xcstr(prefix_utf), NULL)
             del self._global_namespaces[:]
-    
+
     cdef void _unregisterNamespace(self, prefix_utf):
         xpath.xmlXPathRegisterNs(self._xpathCtxt,
                                  _xcstr(prefix_utf), NULL)
-    
+
     # extension functions
 
     cdef int _addLocalExtensionFunction(self, ns_utf, name_utf, function) except -1:

--- a/src/lxml/tests/test_xpathevaluator.py
+++ b/src/lxml/tests/test_xpathevaluator.py
@@ -30,7 +30,7 @@ class ETreeXPathTestCase(HelperTestCase):
         expected = ['nan', '1.#qnan', 'nanq']
         if not actual.lower() in expected:
             self.fail('Expected a NAN value, got %s' % actual)
-        
+
     def test_xpath_string(self):
         tree = self.parse('<a>Foo</a>')
         self.assertEqual('Foo',
@@ -64,7 +64,7 @@ class ETreeXPathTestCase(HelperTestCase):
         # this seems to pass a different code path, also should return nothing
         self.assertEqual([],
                           tree.xpath('/a/c/text()'))
-    
+
     def test_xpath_list_text(self):
         tree = self.parse('<a><b>Foo</b><b>Bar</b></a>')
         root = tree.getroot()
@@ -319,7 +319,7 @@ class ETreeXPathTestCase(HelperTestCase):
         self.assertEqual(
             [root[0][0]],
             e('c'))
-        
+
     def test_xpath_extensions(self):
         def foo(evaluator, a):
             return 'hello %s' % a
@@ -681,16 +681,16 @@ def stringTest(ctxt, s1):
 
 def stringListTest(ctxt, s1):
     return ["Hello "] + list(s1) +  ["!"]
-    
+
 def floatTest(ctxt, f1):
     return f1+4
 
 def booleanTest(ctxt, b1):
     return not b1
-    
+
 def setTest(ctxt, st1):
     return st1[0]
-    
+
 def setTest2(ctxt, st1):
     return st1[0:2]
 
@@ -706,7 +706,7 @@ def resultTypesTest(ctxt):
 
 def resultTypesTest2(ctxt):
     return resultTypesTest
-    
+
 uri = "http://www.example.com/"
 
 extension = {(None, 'stringTest'): stringTest,
@@ -723,7 +723,7 @@ extension = {(None, 'stringTest'): stringTest,
 def xpath():
     """
     Test xpath extension functions.
-    
+
     >>> root = SAMPLE_XML
     >>> e = etree.XPathEvaluator(root, extensions=[extension])
     >>> e("stringTest('you')")

--- a/src/lxml/tests/test_xpathevaluator.py
+++ b/src/lxml/tests/test_xpathevaluator.py
@@ -210,6 +210,12 @@ class ETreeXPathTestCase(HelperTestCase):
             self.assertTrue(evaluator('./text/body')[0].tag.endswith('}body'))
             self.assertEqual(len(evaluator('.//body/x:svg')), 1)
 
+    def _test_xpath_smart_prefix_transparency(self):
+        tree = self.parse('<TEI xmlns="http://www.tei-c.org/ns/1.0"><text></text></TEI>')
+        element = tree.xpath('./text', smart_prefix=True)
+        self.assertIsNone(element.prefix)
+        self.assertContains(element.nsmap, None)
+
     def test_xpath_with_predicates_smart_prefix(self):
         tree = self.parse('<root xmlns="uri_a"><b foo="1" /><b foo="2"><c /></b></root>')
         evaluator = etree.XPathEvaluator(tree, smart_prefix=True)

--- a/src/lxml/xslt.pxi
+++ b/src/lxml/xslt.pxi
@@ -471,7 +471,7 @@ cdef class XSLT:
 
     def apply(self, _input, *, profile_run=False, **kw):
         u"""apply(self, _input,  profile_run=False, **kw)
-        
+
         :deprecated: call the object, not this method."""
         return self(_input, profile_run=profile_run, **kw)
 

--- a/src/lxml/xslt.pxi
+++ b/src/lxml/xslt.pxi
@@ -278,7 +278,10 @@ cdef class _XSLTContext(_BaseContext):
         self._extension_elements = EMPTY_DICT
 
     def __init__(self, namespaces, extensions, error_log, enable_regexp,
-                 build_smart_strings):
+                 build_smart_strings, use_smart_prefix=False):
+        # TODO try enabling it
+        # use_smart_prefix is only to comply with the _BaseContext signature
+        # there's yet no plan to support that option here
         if extensions is not None and extensions:
             for ns_name_tuple, extension in extensions.items():
                 if ns_name_tuple[0] is None:
@@ -293,7 +296,7 @@ cdef class _XSLTContext(_BaseContext):
                     self._extension_elements[(ns_utf, name_utf)] = extension
                     del extensions[ns_name_tuple]
         _BaseContext.__init__(self, namespaces, extensions, error_log, enable_regexp,
-                              build_smart_strings)
+                              build_smart_strings, False)
 
     cdef _BaseContext _copy(self):
         cdef _XSLTContext context


### PR DESCRIPTION
> Namespaces are one honking great idea -- let's do more of those!

Using XPath to locate elements is quiet cumbersome when it comes to documents that have a default namespace:

```python
>>> root = etree.fromstring('<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:x="http://www.w3.org/2000/svg"><text><body><x:svg /></body></text></TEI>')
>>> root.nsmap
{'x': 'http://www.w3.org/2000/svg', None: 'http://www.tei-c.org/ns/1.0'}
>>> root.xpath('./text/body')
[]
>>> root.xpath('./text/body', namespaces=root.nsmap)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    root.xpath('./text/body', namespaces=root.nsmap)
  File "src/lxml/lxml.etree.pyx", line 1584, in lxml.etree._Element.xpath (src/lxml/lxml.etree.c:59349)
    evaluator = XPathElementEvaluator(self, namespaces=namespaces,
  File "src/lxml/xpath.pxi", line 261, in lxml.etree.XPathElementEvaluator.__init__ (src/lxml/lxml.etree.c:170589)
  File "src/lxml/xpath.pxi", line 133, in lxml.etree._XPathEvaluatorBase.__init__ (src/lxml/lxml.etree.c:168702)
  File "src/lxml/xpath.pxi", line 57, in lxml.etree._XPathContext.__init__ (src/lxml/lxml.etree.c:167658)
    _BaseContext.__init__(self, namespaces, extensions, error_log, enable_regexp,
  File "src/lxml/extensions.pxi", line 84, in lxml.etree._BaseContext.__init__ (src/lxml/lxml.etree.c:156529)
    if namespaces:
TypeError: empty namespace prefix is not supported in XPath
```

This is a [well](http://lxml.de/xpathxslt.html) [documented](http://lxml.de/FAQ.html#xpath-and-document-traversal) [issue](http://git.net/ml/python-lxml-devel/2009-08/msg00039.html) ([also here](https://stackoverflow.com/questions/8053568/how-do-i-use-empty-namespaces-in-an-lxml-xpath-query)) and is [commonly solved](https://stackoverflow.com/questions/31177707/parsing-xml-containing-default-namespace-to-get-an-element-value-using-lxml) by manipulating the namespace mapping with an ad-hoc prefix - which loses the information what the default namespace was unless preserved - and adding that to XPath expressions. ([another hack](https://stackoverflow.com/questions/5572247/how-to-find-xml-elements-via-xpath-in-python-in-a-namespace-agnostic-way), [stdlib as well](http://www.goodmami.org/2015/11/04/python-xpath-and-default-namespaces.html) with some insights)

But this solution doesn't play well in generalising code like adapter classes where it becomes tedious and error prone because XPath expressions are not always identical (did i mention they are counter-intuitive to type?) and keeping track of namespace mappings across loosely coupled code elements introduces boilerplates. 

Ultimately, the interplay of document namespaces and XPath expressions is everything but pythonic and rather complicated than complex, though
 
> There should be one-- and preferably only one --obvious way to do it.

The root of this issue is caused by [a flaw](https://lists.w3.org/Archives/Public/www-dom/2002JulSep/0159.html) in the [XPath 1.0](https://www.w3.org/TR/xpath/#node-tests) specs that `libxml2` follows in its implementation:

> A QName in the node test is expanded into an expanded-name using the namespace declarations from the expression context. This is the same way expansion is done for element type names in start and end-tags except that the default namespace declared with xmlns is not used: **if the QName does not have a prefix, then the namespace URI is null** (this is the same way attribute names are expanded). It is an error if the QName has a prefix for which there is no namespace declaration in the expression context.

While [XML namespaces](https://www.w3.org/TR/REC-xml-names/#ns-decl) actually have a notion of an unaliased default namespace:

> If the attribute name matches DefaultAttName, then the namespace name in the attribute value is that of the default namespace in the scope of the element to which the declaration is attached.

[XPath 2.0](https://www.w3.org/TR/xpath20/#node-tests) did eventually fix this:

> A QName in a name test is resolved into an expanded QName using the statically known namespaces in the expression context. It is a static error [err:XPST0081] if the QName has a prefix that does not correspond to any statically known namespace. **An unprefixed QName, when used as a name test on an axis whose principal node kind is element, has the namespace URI of the default element/type namespace in the expression context**; otherwise, it has no namespace URI.

There's no XPath 2.0 implementation with Python bindings around (well, there is one to XQuilla that returns raw strings and is far off `lxml`'s capabilities), and it is very unlikely there's one to be implemented as the extension as a whole is a lot - which probably no one needs outside the XQuery/XSLT scene. [`libxml2` didn't intend to](https://www.mail-archive.com/xml@gnome.org/msg04082.html) ten years ago, but hey, [looking for a thesis](https://diplomky.redhat.com/topic/show/190/xpath-20-support-to-libxml) to write?

Thus I propose to backport that bug fix from XPath 2.0 to `lxml`'s XPath interfaces with an opt-in `smart_prefix` option without considering the whole standard as  

> practicality beats purity.

Behind the scenes the ad-hoc prefix 'solution' described above is applied, but completely hidden from the client code.

This pull request demonstrates the design and isn't completed yet, at least these issues still need to be addressed:

- documentation
- predicates are handled rather hackish and i have doubts that it works with more complex predicates
  - i'd appreciate test proposals for practical examples with such
  - support for predicates with the `smart_prefix` option could be dropped altogether, finer-grained selection is possible with Python and probably a common usage
- should this even be the default behavior with opt-out? afaict it wouldn't break any code as supplying a namespace map with a default namespace (mapped to `None`) is currently invalid 
  - i'd keep it out of XSLT anyway
- should result elements from such queries have a property that stores the option? so later calls on `.xpath()` of these elements would behave the same if no `smart_prefix` option is provided
- can `regex.h` be used directly from Cython, but that's not specific to this here

btw, this is the first time i used Cython and my C usage was long ago, i'm happy about every feedback for improvements.

Now, let's have some fun:

```python
>>> root = etree.fromstring('<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:x="http://www.w3.org/2000/svg"><text><body><x:svg /></body></text></TEI>')
>>> root.nsmap
{None: 'http://www.tei-c.org/ns/1.0', 'x': 'http://www.w3.org/2000/svg'}
>>> root.xpath('./text/body', namespaces=root.nsmap, smart_prefix=True)
[<Element {http://www.tei-c.org/ns/1.0}body at 0x7f8e655587c8>]
>>> root.xpath('./text/body', smart_prefix=True)
[<Element {http://www.tei-c.org/ns/1.0}body at 0x7f8e655587c8>]
```

(oh, the inplace build option fails on my local machine without a helpful message. does anyone have a hint on that?)
