### PR TITLE
Fix typo in doc on mentioned `requests` library

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -858,7 +858,7 @@ The ``parse()`` function supports any of the following sources:
 Note that passing a filename or URL is usually faster than passing an
 open file or file-like object.  However, the HTTP/FTP client in libxml2
 is rather simple, so things like HTTP authentication require a dedicated
-URL request library, e.g. ``urllib2`` or ``request``.  These libraries
+URL request library, e.g. ``urllib2`` or ``requests``.  These libraries
 usually provide a file-like object for the result that you can parse
 from while the response is streaming in.
 


### PR DESCRIPTION
I'm sure the author of the documentation wanted to refer to the library `requests` and not `request`.