### PR TITLE
properly enable in-code hex entity encoder

### DIFF
--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -464,7 +464,7 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
             with xf.element("tagname", attrib={"attr": _str('"misquöted\\u3344\\U00013344"')}):
                 xf.write("foo")
 
-        self.assertXml('<tagname attr="&quot;misqu&#246;ted&#13124;&#78660;&quot;">foo</tagname>')
+        self.assertXml('<tagname attr="&quot;misqu&#xF6;ted&#x3344;&#x13344;&quot;">foo</tagname>')
 
     def test_unescaped_script(self):
         with etree.htmlfile(self._file) as xf:


### PR DESCRIPTION
Function `_write_attr_string` improperly handles the fact that signedness of `char` is implementation- and platform-defined. Furthermore, in x86-land, the default is signed char, so `cur[0] >= 0x80` is always false and the whole branch is dead code.

That means that function `xmlSerializeHexCharRef` never actually executed and the encoding was happening magically inside libxml. (This is evidenced by the fact that `xmlSerializeHexCharRef` generates hex-based entities, but `test_attribute_quoting_unicode` was checking for decimal-based encoding. With that said, I'm very curious if commit 7eef15864c9dfdc74ac6182ce15fea07fe600af1 ever actually did anything?)

This PR forces using unsigned chars where appropriate, fixes incorrect `xmlOutputBufferWrite` call, and updates the testcase to test for hex-based encoding.