### PR TITLE
add adoptExternalDocument to public header

### DIFF
--- a/src/lxml/includes/etreepublic.pxd
+++ b/src/lxml/includes/etreepublic.pxd
@@ -50,10 +50,6 @@ cdef extern from "lxml.etree_api.h":
         cdef object (*_fallback_function)(object, _Document, tree.xmlNode*)
 
     ##########################################################################
-    # creating Document objects
-    cdef _Document documentFactory(tree.xmlDoc* c_doc, parser)
-
-    ##########################################################################
     # creating Element objects
 
     # create an Element for a C-node in the Document
@@ -64,6 +60,9 @@ cdef extern from "lxml.etree_api.h":
 
     # create an ElementTree subclass for an Element
     cdef _ElementTree newElementTree(_Element context_node, object subclass)
+
+    # create an ElementTree from an external document
+    cdef _ElementTree adoptExternalDocument(tree.xmlDoc* c_doc, parser, bint is_owned)
 
     # create a new Element for an existing or new document (doc = None)
     # builds Python object after setting text, tail, namespaces and attributes

--- a/src/lxml/includes/etreepublic.pxd
+++ b/src/lxml/includes/etreepublic.pxd
@@ -50,6 +50,10 @@ cdef extern from "lxml.etree_api.h":
         cdef object (*_fallback_function)(object, _Document, tree.xmlNode*)
 
     ##########################################################################
+    # creating Document objects
+    cdef _Document documentFactory(tree.xmlDoc* c_doc, parser)
+
+    ##########################################################################
     # creating Element objects
 
     # create an Element for a C-node in the Document

--- a/src/lxml/public-api.pxi
+++ b/src/lxml/public-api.pxi
@@ -17,10 +17,11 @@ cdef public api _ElementTree newElementTree(_Element context_node,
     _assertValidNode(context_node)
     return _newElementTree(context_node._doc, context_node, subclass)
 
-cdef public api _Document documentFactory(xmlDoc* c_doc, parser):
+cdef public api _ElementTree adoptExternalDocument(xmlDoc* c_doc, parser, bint is_owned):
     if c_doc is NULL:
         raise TypeError
-    return _documentFactory(c_doc, parser)
+    doc = _adoptForeignDoc(c_doc, parser, is_owned)
+    return _elementTreeFactory(doc, None)
 
 cdef public api _Element elementFactory(_Document doc, xmlNode* c_node):
     if c_node is NULL or doc is None:

--- a/src/lxml/public-api.pxi
+++ b/src/lxml/public-api.pxi
@@ -17,6 +17,11 @@ cdef public api _ElementTree newElementTree(_Element context_node,
     _assertValidNode(context_node)
     return _newElementTree(context_node._doc, context_node, subclass)
 
+cdef public api _Document documentFactory(xmlDoc* c_doc, parser):
+    if c_doc is NULL:
+        raise TypeError
+    return _documentFactory(c_doc, parser)
+
 cdef public api _Element elementFactory(_Document doc, xmlNode* c_node):
     if c_node is NULL or doc is None:
         raise TypeError


### PR DESCRIPTION
Allows the creation of LxmlDocument structs used throughout lxml.etree from a raw libxml xmlDoc pointer in a C/Cython extension.

Example usage:

```cython
cimport lxml.includes.etreepublic as cetree
from lxml.includes.etreepublic cimport tree

# import the lxml.etree module in Python
cdef object etree
from lxml import etree

# initialize the access to the C-API of lxml.etree
cetree.import_lxml__etree()

from lxml.includes.etreepublic cimport _Document, documentFactory

from my_extension cimport some_c_function

_html_parser = etree.HTMLParser()

cdef _Document parse_html(html):
    cdef _Document doc
    cdef tree.xmlDoc* c_doc
    c_doc = some_c_function(html)
    doc = documentFactory(c_doc, _html_parser)
    return doc
```

My current use case is the one mentioned in #239 (closed in favor of this, simpler to move that extension to a separate project), where I would like to use an external C HTML parser ([gumbo-parser](https://github.com/google/gumbo-parser)), build a libxml tree from its output ([gumbo-libxml](https://github.com/nostrademons/gumbo-libxml)), and have the ability to run XPaths, cleaner, etc. on said tree using lxml.

This could generally open the door for using other C parsers for lxml.