### PR TITLE
Extract magic string in ElementInclude._include()

### DIFF
--- a/src/lxml/ElementInclude.py
+++ b/src/lxml/ElementInclude.py
@@ -64,6 +64,7 @@ XINCLUDE = "{http://www.w3.org/2001/XInclude}"
 
 XINCLUDE_INCLUDE = XINCLUDE + "include"
 XINCLUDE_FALLBACK = XINCLUDE + "fallback"
+XINCLUDE_ITER_TAG = XINCLUDE + "*"
 
 ##
 # Fatal include error.
@@ -161,7 +162,7 @@ def _include(elem, loader=None, _parent_hrefs=None, base_url=None):
     parser = elem.getroottree().parser
 
     include_elements = list(
-        elem.iter('{http://www.w3.org/2001/XInclude}*'))
+        elem.iter(XINCLUDE_ITER_TAG))
 
     for e in include_elements:
         if e.tag == XINCLUDE_INCLUDE:


### PR DESCRIPTION
ElementInclude defines several constants to refer to the relevant namespace - `XINCLUDE`, `XINCLUDE_INCLUDE` and `XINCLUDE_FALLBACK`. These constants are then used within `_include()`.

This change takes a remaining magic use of the namespace within `_include()` and extracts it to become a constant with the others. Doing this makes it possible to utilise an alternative namespace without having to modify `_include()`.