### PR TITLE
Build for all python versions that also in travis

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,13 @@ version: 1.0.{build}
 environment:
   matrix:
   - python: 26
+  - python: 26-x64
   - python: 27
+  - python: 27-x64
+  - python: 33
+  - python: 33-x64
+  - python: 34
+  - python: 34-x64
   - python: 35
   - python: 35-x64
   - python: 36


### PR DESCRIPTION
From the travis file, it seems like lxml might be officially be supporting 

python 2.6, 2.7, 3.3, 3.4,. 3.5, 3.6.

This PR makes lxml on appveyor for these versions as well. 