### PR TITLE
Capture error location

### DIFF
--- a/src/lxml/extensions.pxi
+++ b/src/lxml/extensions.pxi
@@ -413,6 +413,7 @@ cdef void _forwardXPathError(void* c_ctxt, xmlerror.xmlError* c_error) with gil:
     error.line = c_error.line
     error.int2 = c_error.int1 # column
     error.file = c_error.file
+    error.node = NULL
 
     (<_BaseContext>c_ctxt)._error_log._receive(&error)
 

--- a/src/lxml/includes/xmlerror.pxd
+++ b/src/lxml/includes/xmlerror.pxd
@@ -835,6 +835,7 @@ cdef extern from "libxml/xmlerror.h":
         int line
         int int1
         int int2
+        void* node
 
     ctypedef void (*xmlGenericErrorFunc)(void* ctxt, char* msg, ...) nogil
     ctypedef void (*xmlStructuredErrorFunc)(void* userData,

--- a/src/lxml/tests/test_xmlschema.py
+++ b/src/lxml/tests/test_xmlschema.py
@@ -80,7 +80,7 @@ class ETreeXMLSchemaTestCase(HelperTestCase):
         schema.validate(tree)
         tree_path = tree.getpath(tree.findall('b')[1])
         error_path = schema.error_log[0].path
-        self.assertTrue(tree_path == error_path)
+        self.assertTrue(error_path is None or tree_path == error_path)
 
     def test_xmlschema_default_attributes(self):
         schema = self.parse('''

--- a/src/lxml/tests/test_xmlschema.py
+++ b/src/lxml/tests/test_xmlschema.py
@@ -65,6 +65,15 @@ class ETreeXMLSchemaTestCase(HelperTestCase):
             etree.ErrorTypes.SCHEMAV_ELEMENT_CONTENT))
 
     def test_xmlschema_error_log_path(self):
+        """We don't have a guarantee that there will always be a path
+        for a _LogEntry object (or even a node for which to determina
+        a path), but at least when this test was created schema validation
+        errors always got a node and an XPath value. If that ever changes,
+        we can modify this test to something like:
+            self.assertTrue(error_path is None or tree_path == error_path)
+        That way, we can at least verify that if we did get a path value
+        it wasn't bogus.
+        """
         tree = self.parse('<a><b>42</b><b>dada</b></a>')
         schema = self.parse('''
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -80,7 +89,7 @@ class ETreeXMLSchemaTestCase(HelperTestCase):
         schema.validate(tree)
         tree_path = tree.getpath(tree.findall('b')[1])
         error_path = schema.error_log[0].path
-        self.assertTrue(error_path is None or tree_path == error_path)
+        self.assertTrue(tree_path == error_path)
 
     def test_xmlschema_default_attributes(self):
         schema = self.parse('''

--- a/src/lxml/tests/test_xmlschema.py
+++ b/src/lxml/tests/test_xmlschema.py
@@ -64,6 +64,24 @@ class ETreeXMLSchemaTestCase(HelperTestCase):
         self.assertTrue(schema.error_log.filter_types(
             etree.ErrorTypes.SCHEMAV_ELEMENT_CONTENT))
 
+    def test_xmlschema_error_log_path(self):
+        tree = self.parse('<a><b>42</b><b>dada</b></a>')
+        schema = self.parse('''
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:element name="a" type="AType"/>
+  <xsd:complexType name="AType">
+    <xsd:sequence>
+      <xsd:element name="b" type="xsd:integer" maxOccurs="2"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>
+''')
+        schema = etree.XMLSchema(schema)
+        schema.validate(tree)
+        tree_path = tree.getpath(tree.findall('b')[1])
+        error_path = schema.error_log[0].path
+        self.assertTrue(tree_path == error_path)
+
     def test_xmlschema_default_attributes(self):
         schema = self.parse('''
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">

--- a/src/lxml/xmlerror.pxi
+++ b/src/lxml/xmlerror.pxi
@@ -633,7 +633,7 @@ cdef void _receiveXSLTError(void* c_log_handler, char* msg, ...) nogil:
     if msg[0] in b'\n\0':
         return
 
-    c_text = c_element = c_error.file = NULL
+    c_text = c_element = c_error.file = c_error.node = NULL
     c_error.line = 0
 
     # parse "NAME %s" chunks from the format string

--- a/src/lxml/xmlerror.pxi
+++ b/src/lxml/xmlerror.pxi
@@ -49,6 +49,7 @@ cdef class _LogEntry:
     - line: the line at which the message originated (if applicable)
     - column: the character column at which the message originated (if applicable)
     - filename: the name of the file in which the message originated (if applicable)
+    - path: the location in which the error was found (if available)
     """
     cdef readonly int domain
     cdef readonly int type
@@ -59,10 +60,12 @@ cdef class _LogEntry:
     cdef basestring _filename
     cdef char* _c_message
     cdef xmlChar* _c_filename
+    cdef xmlChar* _c_path
 
     def __dealloc__(self):
         tree.xmlFree(self._c_message)
         tree.xmlFree(self._c_filename)
+        tree.xmlFree(self._c_path)
 
     @cython.final
     cdef _setError(self, xmlerror.xmlError* error):
@@ -73,6 +76,7 @@ cdef class _LogEntry:
         self.column   = error.int2
         self._c_message = NULL
         self._c_filename = NULL
+        self._c_path = NULL
         if (error.message is NULL or
                 error.message[0] == b'\0' or
                 error.message[0] == b'\n' and error.message[1] == b'\0'):
@@ -90,6 +94,8 @@ cdef class _LogEntry:
             self._c_filename = tree.xmlStrdup(<const_xmlChar*> error.file)
             if not self._c_filename:
                 raise MemoryError()
+        if error.node is not NULL:
+            self._c_path = tree.xmlGetNodePath(<xmlNode*> error.node)
 
     @cython.final
     cdef _setGeneric(self, int domain, int type, int level, int line,
@@ -101,6 +107,7 @@ cdef class _LogEntry:
         self.column  = 0
         self._message = message
         self._filename = filename
+        self._c_path = NULL
 
     def __repr__(self):
         return u"%s:%d:%d:%s:%s:%s: %s" % (
@@ -164,6 +171,12 @@ cdef class _LogEntry:
                     tree.xmlFree(self._c_filename)
                     self._c_filename = NULL
             return self._filename
+
+    property path:
+        """The XPath for the node where the error was detected.
+        """
+        def __get__(self):
+            return funicode(self._c_path) if self._c_path is not NULL else None
 
 
 cdef class _BaseErrorLog:

--- a/src/lxml/xmlerror.pxi
+++ b/src/lxml/xmlerror.pxi
@@ -152,7 +152,7 @@ cdef class _LogEntry:
                 self._message = self._c_message[:size].decode('utf8')
             except UnicodeDecodeError:
                 try:
-                    self.message = self._c_message[:size].decode(
+                    self._message = self._c_message[:size].decode(
                         'ascii', 'backslashreplace')
                 except UnicodeDecodeError:
                     self._message = u'<undecodable error message>'


### PR DESCRIPTION
Add `path` property to `_LogEntry` object.

This patch gets the XPath value from libxml2 for the node in which an error was detected (if available), and exposes that value as a property of the `_LogEntry` object, enabling user interface code to navigate the end user to the location of each error. Code which assembles `xmlError` structs outside of libxml2 is modified to initialize the node member of that struct. A typo in the assignment to the cached value for the `_LogEntry`'s message property is also fixed.