### PR TITLE
Added caveat to dict-of-dicts code

### DIFF
--- a/doc/FAQ.txt
+++ b/doc/FAQ.txt
@@ -365,6 +365,8 @@ I'm glad you asked.
          return element.tag, \
                 dict(map(recursive_dict, element)) or element.text
 
+Note `recursive_dict` will overwrite any data contained in siblings
+with the same tag.
 
 Why does lxml sometimes return 'str' values for text in Python 2?
 -----------------------------------------------------------------


### PR DESCRIPTION
The code given to transform an element to a dict of dicts will overwrite information in parallel tags, so `<a><b>c</b><b>d</b></a>` will become `{'a':{'b':'d'}}`.  I've taken a stab at writing a replacement that places duplicated tags in arrays [here](https://gist.github.com/SKalt/9fdef848e4917538bd53a7d2368c1a9f); suggestions appreciated.