### PR TITLE
Fix getargspec DeprecationWarning

### DIFF
--- a/src/lxml/parsertarget.pxi
+++ b/src/lxml/parsertarget.pxi
@@ -2,9 +2,9 @@
 
 cdef object inspect_getargspec
 try:
-    from inspect import getargspec as inspect_getargspec
-except ImportError:
     from inspect import getfullargspec as inspect_getargspec
+except ImportError:
+    from inspect import getargspec as inspect_getargspec
 
 
 class _TargetParserResult(Exception):


### PR DESCRIPTION
Try to import the newer method (getfullargspec) and only fall back to getargspec if it can't be imported. This should resolve the DeprecationWarning from getargspec being imported.