### PR TITLE
Support using pkg-config for xml2-config/xslt-config tools

### DIFF
--- a/doc/build.txt
+++ b/doc/build.txt
@@ -115,6 +115,14 @@ setup.py to make sure the right config is found::
 
   python setup.py build --with-xslt-config=/path/to/xslt-config
 
+There are also env vars to allow overriding the config tool::
+
+  env XML2_CONFIG=/path/to/xml2-config python build
+
+You may also use ``pkg-config`` as the tools::
+
+  env XSLT_CONFIG="pkg-config libxslt" python setup.py build
+
 If this doesn't help, you may have to add the location of the header
 files to the include path like::
 

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -384,9 +384,15 @@ def check_min_version(version, min_version, error_name):
     return True
 
 
+def get_library_version(config_tool):
+    is_pkgconfig = "pkg-config" in config_tool
+    return run_command(config_tool,
+                       "--modversion" if is_pkgconfig else "--version")
+
+
 def get_library_versions():
-    xml2_version = run_command(find_xml2_config(), "--version")
-    xslt_version = run_command(find_xslt_config(), "--version")
+    xml2_version = get_library_version(find_xml2_config())
+    xslt_version = get_library_version(find_xslt_config())
     return xml2_version, xslt_version
 
 


### PR DESCRIPTION
Those tools are not supported on some distributions where pkg-config is recommended and otherwise works fine.