### PR TITLE
Add missing huge_tree parameter to XMLParser docstring

### DIFF
--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1438,7 +1438,7 @@ _XML_DEFAULT_PARSE_OPTIONS = (
     )
 
 cdef class XMLParser(_FeedParser):
-    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, schema: XMLSchema =None, remove_blank_text=False, resolve_entities=True, remove_comments=False, remove_pis=False, strip_cdata=True, collect_ids=True, target=None, compact=True)
+    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, schema: XMLSchema =None, huge_tree=False, remove_blank_text=False, resolve_entities=True, remove_comments=False, remove_pis=False, strip_cdata=True, collect_ids=True, target=None, compact=True)
 
     The XML parser.
 


### PR DESCRIPTION
The `huge_tree` parameter is missing from the docstring definition of the `XMLParser` class. This causes PyCharm to report a false positive when this parameter is used: https://youtrack.jetbrains.com/issue/PY-21959

This PR adds the parameter to the docstring.

Bug reported at: https://bugs.launchpad.net/lxml/+bug/1765437