### PR TITLE
Link libz only for static builds

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -268,7 +268,7 @@ def libraries():
     standard_libs = []
     if 'linux' in sys.platform:
         standard_libs.append('rt')
-    if not OPTION_BUILD_LIBXML2XSLT:
+    if OPTION_STATIC:
         standard_libs.append('z')
     standard_libs.append('m')
 


### PR DESCRIPTION
If a user is not building libxml2 and is linking to it dynamically, then
there is no additional need to link to libz, since libxml2 will be
depending on libz anyway.