### PR TITLE
Fixing possible memory corruption in doc dictionary if node is moved between docs

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -917,7 +917,7 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
         if c_node is NULL:
             _appendChild(self, element)
             return
-        c_source_doc = c_node.doc
+        c_source_doc = element._c_node.doc
         c_next = element._c_node.next
         tree.xmlAddPrevSibling(c_node, element._c_node)
         _moveTail(c_next, element._c_node)


### PR DESCRIPTION
etree.insert function tries to handle the case when a node is moved
between documents with the function moveNodeToDocument. So far the
source_doc is taken from the destination child node which is wrong.
The moveNodeToDocument function will not fix the names in the
document dictionaries because source and target doc are the same.

The fix takes now the source_doc from the node element which
should be inserted.

This fixes issue https://bugs.launchpad.net/lxml/+bug/1773749