### PR TITLE
Make .nsmap available in XSLT extensions.

### DIFF
--- a/src/lxml/readonlytree.pxi
+++ b/src/lxml/readonlytree.pxi
@@ -290,6 +290,26 @@ cdef class _ReadOnlyElementProxy(_ReadOnlyProxy):
                     return funicode(self._c_node.ns.prefix)
             return None
 
+    property nsmap:
+        u"""Namespace prefix->URI mapping known in the context of this
+        Element.
+        """
+        def __get__(self):
+            self._assertNode()
+            cdef xmlNode* c_node
+            cdef xmlNs* c_ns
+            nsmap = {}
+            c_node = self._c_node
+            while c_node is not NULL and c_node.type == tree.XML_ELEMENT_NODE:
+                c_ns = c_node.nsDef
+                while c_ns is not NULL:
+                    prefix = funicodeOrNone(c_ns.prefix)
+                    if prefix not in nsmap:
+                        nsmap[prefix] = funicodeOrNone(c_ns.href)
+                    c_ns = c_ns.next
+                c_node = c_node.parent
+            return nsmap
+
     def get(self, key, default=None):
         u"""Gets an element attribute.
         """

--- a/src/lxml/tests/test_xslt.py
+++ b/src/lxml/tests/test_xslt.py
@@ -1936,6 +1936,42 @@ class ETreeXSLTExtElementTestCase(HelperTestCase):
             b'<p style="color:red">This is *-arbitrary-* text in a paragraph</p>\n',
             etree.tostring(result))
 
+    def test_extensions_nsmap(self):
+        tree = self.parse("""\
+<root>
+  <inner xmlns:sha256="http://www.w3.org/2001/04/xmlenc#sha256">
+    <data>test</data>
+  </inner>
+</root>
+""")
+        style = self.parse("""\
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:my="extns" extension-element-prefixes="my" version="1.0">
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="data">
+    <my:show-nsmap/>
+  </xsl:template>
+</xsl:stylesheet>
+""")
+        class MyExt(etree.XSLTExtension):
+            def execute(self, context, self_node, input_node, output_parent):
+                output_parent.text = str(input_node.nsmap)
+
+        extensions = { ('extns', 'show-nsmap') : MyExt() }
+
+        result = tree.xslt(style, extensions=extensions)
+        self.assertEqual(etree.tostring(result, pretty_print=True), """\
+<root>
+  <inner xmlns:sha256="http://www.w3.org/2001/04/xmlenc#sha256">{\'sha256\': \'http://www.w3.org/2001/04/xmlenc#sha256\'}
+  </inner>
+</root>
+""")
+
+
 
 class Py3XSLTTestCase(HelperTestCase):
     """XSLT tests for etree under Python 3"""


### PR DESCRIPTION
When adding namespaced elements/attributes in `execute` of XSLT extension element, new `xmlns` declaration is generated with prefix `ns0`. At the same time it does not seem to be possible to figure out what are the existing namespaces and prefixes in the `input_node`, resulting in
```
AttributeError: 'lxml.etree._ReadOnlyElementProxy' object has no attribute 'nsmap'
```
This patch makes it possible to see the namespace map.