### PR TITLE
Remove redundant Python <= 2.6 code

### DIFF
--- a/DD.py
+++ b/DD.py
@@ -447,7 +447,7 @@ class DD(object):
     def _old_dd(self, c, r, n):
         """Stub to overload in subclasses"""
 
-        if r == []:
+        if not r:
             assert self.test([]) == self.PASS
             assert self.test(c)  == self.FAIL
         else:
@@ -498,7 +498,7 @@ class DD(object):
 
 
                 doubled =  self.__listintersect(cbar, cs[i])
-                if doubled != []:
+                if doubled:
                     cs[i] = self.__listminus(cs[i], doubled)
 
 
@@ -661,7 +661,7 @@ class DD(object):
                     t, cbars[i] = self.test_mix(cbars[i], c, self.ADD)
 
                     doubled = self.__listintersect(cbars[i], cs[i])
-                    if doubled != []:
+                    if doubled:
                         cs[i] = self.__listminus(cs[i], doubled)
 
                     if t == self.FAIL:
@@ -864,7 +864,7 @@ if __name__ == '__main__':
             return self.PASS
 
         def _test_b(self, c):
-            if c == []:
+            if not c:
                 return self.PASS
             if 1 in c and 2 in c and 3 in c and 4 in c and \
                5 in c and 6 in c and 7 in c and 8 in c:

--- a/DD.py
+++ b/DD.py
@@ -428,9 +428,11 @@ class DD(object):
 
 
     # Delta Debugging (old ESEC/FSE version)
-    def old_dd(self, c, r = [], n = 2):
+    def old_dd(self, c, r=None, n = 2):
         """Return the failure-inducing subset of C"""
 
+        if r is None:
+            r = []
         assert self.test([]) == dd.PASS
         assert self.test(c)  == dd.FAIL
 

--- a/DD.py
+++ b/DD.py
@@ -428,11 +428,9 @@ class DD(object):
 
 
     # Delta Debugging (old ESEC/FSE version)
-    def old_dd(self, c, r=None, n = 2):
+    def old_dd(self, c, r = [], n = 2):
         """Return the failure-inducing subset of C"""
 
-        if r is None:
-            r = []
         assert self.test([]) == dd.PASS
         assert self.test(c)  == dd.FAIL
 

--- a/DD.py
+++ b/DD.py
@@ -105,10 +105,10 @@ class OutcomeCache(object):
         # Let K0 be the largest element in TAIL such that K0 <= C[START]
         k0 = None
         for k in self.tail.keys():
-            if (k0 == None or k > k0) and k <= c[start]:
+            if (k0 is None or k > k0) and k <= c[start]:
                 k0 = k
 
-        if k0 != None:
+        if k0 is not None:
             return self.tail[k0].lookup_superset(c, start)
         
         return None
@@ -130,20 +130,20 @@ class OutcomeCache(object):
 def oc_test():
     oc = OutcomeCache()
 
-    assert oc.lookup([1, 2, 3]) == None
+    assert oc.lookup([1, 2, 3]) is None
     oc.add([1, 2, 3], 4)
     assert oc.lookup([1, 2, 3]) == 4
-    assert oc.lookup([1, 2, 3, 4]) == None
+    assert oc.lookup([1, 2, 3, 4]) is None
 
-    assert oc.lookup([5, 6, 7]) == None
+    assert oc.lookup([5, 6, 7]) is None
     oc.add([5, 6, 7], 8)
     assert oc.lookup([5, 6, 7]) == 8
     
-    assert oc.lookup([]) == None
+    assert oc.lookup([]) is None
     oc.add([], 0)
     assert oc.lookup([]) == 0
     
-    assert oc.lookup([1, 2]) == None
+    assert oc.lookup([1, 2]) is None
     oc.add([1, 2], 3)
     assert oc.lookup([1, 2]) == 3
     assert oc.lookup([1, 2, 3]) == 4
@@ -154,21 +154,21 @@ def oc_test():
     assert oc.lookup_superset([5, 6]) == 8
     assert oc.lookup_superset([6, 7]) == 8
     assert oc.lookup_superset([7]) == 8
-    assert oc.lookup_superset([]) != None
+    assert oc.lookup_superset([]) is not None
 
-    assert oc.lookup_superset([9]) == None
-    assert oc.lookup_superset([7, 9]) == None
-    assert oc.lookup_superset([-5, 1]) == None
-    assert oc.lookup_superset([1, 2, 3, 9]) == None
-    assert oc.lookup_superset([4, 5, 6, 7]) == None
+    assert oc.lookup_superset([9]) is None
+    assert oc.lookup_superset([7, 9]) is None
+    assert oc.lookup_superset([-5, 1]) is None
+    assert oc.lookup_superset([1, 2, 3, 9]) is None
+    assert oc.lookup_superset([4, 5, 6, 7]) is None
 
     assert oc.lookup_subset([]) == 0
     assert oc.lookup_subset([1, 2, 3]) == 4
     assert oc.lookup_subset([1, 2, 3, 4]) == 4
-    assert oc.lookup_subset([1, 3]) == None
+    assert oc.lookup_subset([1, 3]) is None
     assert oc.lookup_subset([1, 2]) == 3
 
-    assert oc.lookup_subset([-5, 1]) == None
+    assert oc.lookup_subset([-5, 1]) is None
     assert oc.lookup_subset([-5, 1, 2]) == 3
     assert oc.lookup_subset([-5]) == 0
 
@@ -291,7 +291,7 @@ class DD(object):
         # If we had this test before, return its result
         if self.cache_outcomes:
             cached_result = self.outcome_cache.lookup(c)
-            if cached_result != None:
+            if cached_result is not None:
                 return cached_result
 
         if self.monotony:
@@ -387,7 +387,7 @@ class DD(object):
             self.__resolving = 1
             csubr = self.resolve(csubr, c, direction)
 
-            if csubr == None:
+            if csubr is None:
                 # Nothing left to resolve
                 break
             
@@ -406,7 +406,7 @@ class DD(object):
             t = self.test(csubr)
 
         self.__resolving = 0
-        if csubr == None:
+        if csubr is None:
             return self.UNRESOLVED, initial_csub
 
         # assert t == self.PASS or t == self.FAIL

--- a/DD.py
+++ b/DD.py
@@ -555,7 +555,7 @@ class DD(object):
         if self.minimize:
             (t, csub) = self.test_and_resolve(csub, [], c, direction)
             if t == self.FAIL:
-                return (t, csub)
+                return t, csub
 
         if self.maximize:
             csubbar = self.__listminus(self.CC, csub)
@@ -577,7 +577,7 @@ class DD(object):
             else:
                 t = self.UNRESOLVED
 
-        return (t, csub)
+        return t, csub
 
 
     # Delta Debugging (new ISSTA version)
@@ -746,7 +746,7 @@ class DD(object):
             if n > len(c):
                 # No further minimizing
                 print("dd: done")
-                return (c, c1, c2)
+                return c, c1, c2
 
             self.report_progress(c, "dd")
 
@@ -827,7 +827,7 @@ class DD(object):
                 if n >= len(c):
                     # No further minimizing
                     print("dd: done")
-                    return (c, c1, c2)
+                    return c, c1, c2
 
                 next_n = min(len(c), n * 2)
                 print("dd: increase granularity to %d" % next_n)

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -41,7 +41,7 @@ see below.
 Requirements
 ------------
 
-You need Python 2.6 or later.
+You need Python 2.7 or 3.3+.
 
 Unless you are using a static binary distribution (e.g. from a
 Windows binary installer), lxml requires libxml2 and libxslt to

--- a/benchmark/benchbase.py
+++ b/benchmark/benchbase.py
@@ -11,7 +11,7 @@ def exec_(code, glob):
     if sys.version_info[0] >= 3:
         exec(code, glob)
     else:
-        exec("exec code in glob")
+        exec "exec code in glob"
 
 
 TREE_FACTOR = 1 # increase tree size with '-l / '-L' cmd option
@@ -223,7 +223,7 @@ class TreeBenchMark(object):
                 for i in range(20 * TREE_FACTOR):
                     SubElement(el, tag).tail = text
         t = current_time() - t
-        return (root, t)
+        return root, t
 
     def _setup_tree2(self, text, attributes):
         "tree with 520 * TREE_FACTOR 2nd level and 26 3rd level children"
@@ -239,7 +239,7 @@ class TreeBenchMark(object):
                 for ch2 in atoz:
                     SubElement(el, "{cdefg}%s00001" % ch2).tail = text
         t = current_time() - t
-        return (root, t)
+        return root, t
 
     def _setup_tree3(self, text, attributes):
         "tree of depth 8 + TREE_FACTOR with 3 children per node"
@@ -255,7 +255,7 @@ class TreeBenchMark(object):
             child.text = text
             child.tail = text
         t = current_time() - t
-        return (root, t)
+        return root, t
 
     def _setup_tree4(self, text, attributes):
         "small tree with 26 2nd level and 2 3rd level children"
@@ -269,7 +269,7 @@ class TreeBenchMark(object):
             SubElement(el, "{cdefg}a00001", attributes).tail = text
             SubElement(el, "{cdefg}z00000", attributes).tail = text
         t = current_time() - t
-        return (root, t)
+        return root, t
 
     def benchmarks(self):
         """Returns a list of all benchmarks.
@@ -350,7 +350,7 @@ def buildSuites(benchmark_class, etrees, selected):
                               if match(b[0]) ] ]
                        for bs in benchmarks ]
 
-    return (benchmark_suites, benchmarks)
+    return benchmark_suites, benchmarks
 
 def build_treeset_name(trees, tn, an, serialized, children):
     text = {0:'-', 1:'S', 2:'U'}[tn]

--- a/benchmark/benchbase.py
+++ b/benchmark/benchbase.py
@@ -11,7 +11,7 @@ def exec_(code, glob):
     if sys.version_info[0] >= 3:
         exec(code, glob)
     else:
-        exec "exec code in glob"
+        exec("exec code in glob")
 
 
 TREE_FACTOR = 1 # increase tree size with '-l / '-L' cmd option

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -457,4 +457,4 @@ def build_libxml2xslt(download_dir, build_dir,
         for filename in listdir
         if lib in filename and filename.endswith('.a')]
 
-    return (xml2_config, xslt_config)
+    return xml2_config, xslt_config

--- a/doc/api.txt
+++ b/doc/api.txt
@@ -192,8 +192,7 @@ children.  Using the tree defined above, we get:
   >>> [ child.tag for child in root ]
   ['a', 'b', 'c', 'd']
 
-To iterate in the opposite direction, use the builtin ``reversed()`` function
-that exists in Python 2.4 and later.
+To iterate in the opposite direction, use the builtin ``reversed()`` function.
 
 Tree traversal should use the ``element.iter()`` method:
 
@@ -251,7 +250,7 @@ The most common way to traverse an XML tree is depth-first, which
 traverses the tree in document order.  This is implemented by the
 ``.iter()`` method.  While there is no dedicated method for
 breadth-first traversal, it is almost as simple if you use the
-``collections.deque`` type that is available in Python 2.4 and later.
+``collections.deque`` type.
 
 .. sourcecode:: pycon
 

--- a/doc/xpathxslt.txt
+++ b/doc/xpathxslt.txt
@@ -729,7 +729,7 @@ some ideas to try.
 
 The most simple way to reduce the diversity is by using XSLT
 parameters that you pass at call time to configure the stylesheets.
-The ``partial()`` function in the ``functools`` module of Python 2.5
+The ``partial()`` function in the ``functools`` module
 may come in handy here.  It allows you to bind a set of keyword
 arguments (i.e. stylesheet parameters) to a reference of a callable
 stylesheet.  The same works for instances of the ``XPath()``

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ import os.path
 # for command line options and supported environment variables, please
 # see the end of 'setupinfo.py'
 
-if sys.version_info < (2, 6) or sys.version_info[:2] in [(3, 0), (3, 1)]:
-    print("This lxml version requires Python 2.6, 2.7, 3.2 or later.")
+if sys.version_info < (2, 7) or sys.version_info[:2] in [(3, 0), (3, 1), (3, 2)]:
+    print("This lxml version requires Python 2.7, 3.3 or later.")
     sys.exit(1)
 
 try:

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -1102,8 +1102,8 @@ cdef int _copyNonElementSiblings(xmlNode* c_node, xmlNode* c_target) except -1:
         tree.xmlAddPrevSibling(c_target, c_copy)
         c_sibling = c_sibling.next
     while c_sibling.next != NULL and \
-            (c_sibling.next.type == tree.XML_PI_NODE or \
-                 c_sibling.next.type == tree.XML_COMMENT_NODE):
+            (c_sibling.next.type == tree.XML_PI_NODE or
+             c_sibling.next.type == tree.XML_COMMENT_NODE):
         c_sibling = c_sibling.next
         c_copy = tree.xmlDocCopyNode(c_sibling, c_target.doc, 1)
         if c_copy is NULL:

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -247,7 +247,7 @@ cdef _iter_nsmap(nsmap):
     if len(nsmap) <= 1:
         return nsmap.items()
     # nsmap will usually be a plain unordered dict => avoid type checking overhead
-    if OrderedDict is not None and type(nsmap) is not dict and isinstance(nsmap, OrderedDict):
+    if type(nsmap) is not dict and isinstance(nsmap, OrderedDict):
         return nsmap.items()  # keep existing order
     if None not in nsmap:
         return sorted(nsmap.items())
@@ -273,8 +273,7 @@ cdef _iter_attrib(attrib):
     # attrib will usually be a plain unordered dict
     if type(attrib) is dict:
         return sorted(attrib.items())
-    elif isinstance(attrib, _Attrib) or (
-            OrderedDict is not None and isinstance(attrib, OrderedDict)):
+    elif isinstance(attrib, _Attrib) or (isinstance(attrib, OrderedDict)):
         return attrib.items()
     else:
         # assume it's an unordered mapping of some kind

--- a/src/lxml/apihelpers.pxi
+++ b/src/lxml/apihelpers.pxi
@@ -273,7 +273,7 @@ cdef _iter_attrib(attrib):
     # attrib will usually be a plain unordered dict
     if type(attrib) is dict:
         return sorted(attrib.items())
-    elif isinstance(attrib, _Attrib) or (isinstance(attrib, OrderedDict)):
+    elif isinstance(attrib, (_Attrib, OrderedDict)):
         return attrib.items()
     else:
         # assume it's an unordered mapping of some kind

--- a/src/lxml/classlookup.pxi
+++ b/src/lxml/classlookup.pxi
@@ -196,7 +196,7 @@ cdef int _validateNodeClass(xmlNode* c_node, cls) except -1:
     elif c_node.type == tree.XML_PI_NODE:
         expected = PIBase
     else:
-        assert 0, f"Unknown node type: {c_node.type}"
+        assert False, f"Unknown node type: {c_node.type}"
 
     if not (isinstance(cls, type) and issubclass(cls, expected)):
         raise TypeError(
@@ -333,7 +333,7 @@ cdef object _lookupDefaultElementClass(state, _Document _doc, xmlNode* c_node):
         else:
             return (<ElementDefaultClassLookup>state).pi_class
     else:
-        assert 0, f"Unknown node type: {c_node.type}"
+        assert False, f"Unknown node type: {c_node.type}"
 
 
 ################################################################################

--- a/src/lxml/doctestcompare.py
+++ b/src/lxml/doctestcompare.py
@@ -209,9 +209,12 @@ class LXMLOutputChecker(OutputChecker):
             else:
                 return value
         html = parser is html_fromstring
-        diff_parts = ['Expected:', self.format_doc(want_doc, html, 2),
-                      'Got:', self.format_doc(got_doc, html, 2),
-                      'Diff:', self.collect_diff(want_doc, got_doc, html, 2)]
+        diff_parts = ['Expected:',
+                      self.format_doc(want_doc, html, 2),
+                      'Got:',
+                      self.format_doc(got_doc, html, 2),
+                      'Diff:',
+                      self.collect_diff(want_doc, got_doc, html, 2)]
         return '\n'.join(diff_parts)
 
     def html_empty_tag(self, el, html=True):

--- a/src/lxml/doctestcompare.py
+++ b/src/lxml/doctestcompare.py
@@ -209,13 +209,9 @@ class LXMLOutputChecker(OutputChecker):
             else:
                 return value
         html = parser is html_fromstring
-        diff_parts = []
-        diff_parts.append('Expected:')
-        diff_parts.append(self.format_doc(want_doc, html, 2))
-        diff_parts.append('Got:')
-        diff_parts.append(self.format_doc(got_doc, html, 2))
-        diff_parts.append('Diff:')
-        diff_parts.append(self.collect_diff(want_doc, got_doc, html, 2))
+        diff_parts = ['Expected:', self.format_doc(want_doc, html, 2),
+                      'Got:', self.format_doc(got_doc, html, 2),
+                      'Diff:', self.collect_diff(want_doc, got_doc, html, 2)]
         return '\n'.join(diff_parts)
 
     def html_empty_tag(self, el, html=True):

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -66,10 +66,7 @@ cdef object BytesIO, StringIO
 from io import BytesIO, StringIO
 
 cdef object OrderedDict = None
-try:
-    from collections import OrderedDict
-except ImportError:
-    pass
+from collections import OrderedDict
 
 cdef object _elementpath
 from lxml import _elementpath
@@ -91,7 +88,7 @@ cdef object ITER_EMPTY = iter(())
 try:
     from collections.abc import MutableMapping  # Py3.3+
 except ImportError:
-    from collections import MutableMapping  # Py2.6+
+    from collections import MutableMapping  # Py2.7
 
 class _ImmutableMapping(MutableMapping):
     def __getitem__(self, key):
@@ -3437,7 +3434,6 @@ def adopt_external_document(capsule, _BaseParser parser=None):
 
     This allows external libraries to build XML/HTML trees using libxml2
     and then pass them efficiently into lxml for further processing.
-    Requires Python 2.7 or later.
 
     If a ``parser`` is provided, it will be used for configuring the
     lxml document.  No parsing will be done.
@@ -3461,9 +3457,6 @@ def adopt_external_document(capsule, _BaseParser parser=None):
     If no copy is made, later modifications of the tree outside of lxml
     should not be attempted after transferring the ownership.
     """
-    if python.PY_VERSION_HEX < 0x02070000:
-        raise NotImplementedError("PyCapsule usage requires Python 2.7+")
-
     cdef xmlDoc* c_doc
     cdef bint is_owned = False
     c_doc = <xmlDoc*> python.lxml_unpack_xmldoc_capsule(capsule, &is_owned)

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -385,7 +385,7 @@ cdef public class _Document [ type LxmlDocumentType, object LxmlDocument ]:
             root_name = None
         else:
             root_name = funicode(c_root_node.name)
-        return (root_name, public_id, sys_url)
+        return root_name, public_id, sys_url
 
     @cython.final
     cdef getxmlinfo(self):
@@ -399,7 +399,7 @@ cdef public class _Document [ type LxmlDocumentType, object LxmlDocument ]:
             encoding = None
         else:
             encoding = funicode(c_doc.encoding)
-        return (version, encoding)
+        return version, encoding
 
     @cython.final
     cdef isstandalone(self):

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -65,7 +65,7 @@ from os.path import abspath as os_path_abspath
 cdef object BytesIO, StringIO
 from io import BytesIO, StringIO
 
-cdef object OrderedDict = None
+cdef object OrderedDict
 from collections import OrderedDict
 
 cdef object _elementpath

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -27,11 +27,6 @@ except NameError:
     # Python 3
     unicode = str
 try:
-    bytes
-except NameError:
-    # Python < 2.6
-    bytes = str
-try:
     basestring
 except NameError:
     basestring = (str, bytes)

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -538,10 +538,10 @@ _avoid_hosts = [
 
 _avoid_classes = ['nolink']
 
-def autolink(el, link_regexes=None,
-             avoid_elements=None,
-             avoid_hosts=None,
-             avoid_classes=None):
+def autolink(el, link_regexes=_link_regexes,
+             avoid_elements=_avoid_elements,
+             avoid_hosts=_avoid_hosts,
+             avoid_classes=_avoid_classes):
     """
     Turn any URLs into links.
 
@@ -556,14 +556,6 @@ def autolink(el, link_regexes=None,
     If you pass in an element, the element's tail will not be
     substituted, only the contents of the element.
     """
-    if link_regexes is None:
-        link_regexes = _link_regexes
-    if avoid_elements is None:
-        avoid_elements = _avoid_elements
-    if avoid_hosts is None:
-        avoid_hosts = _avoid_hosts
-    if avoid_classes is None:
-        avoid_classes = _avoid_classes
     if el.tag in avoid_elements:
         return
     class_name = el.get('class')
@@ -668,8 +660,8 @@ _avoid_word_break_elements = ['pre', 'textarea', 'code']
 _avoid_word_break_classes = ['nobreak']
 
 def word_break(el, max_width=40,
-               avoid_elements=None,
-               avoid_classes=None,
+               avoid_elements=_avoid_word_break_elements,
+               avoid_classes=_avoid_word_break_classes,
                break_character=unichr(0x200b)):
     """
     Breaks any long words found in the body of the text (not attributes).
@@ -686,10 +678,6 @@ def word_break(el, max_width=40,
     """
     # Character suggestion of &#8203 comes from:
     #   http://www.cs.tut.fi/~jkorpela/html/nobr.html
-    if avoid_elements is None:
-        avoid_elements = _avoid_word_break_elements
-    if avoid_classes is None:
-        avoid_classes = _avoid_word_break_classes
     if el.tag in _avoid_word_break_elements:
         return
     class_name = el.get('class')

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -538,10 +538,10 @@ _avoid_hosts = [
 
 _avoid_classes = ['nolink']
 
-def autolink(el, link_regexes=_link_regexes,
-             avoid_elements=_avoid_elements,
-             avoid_hosts=_avoid_hosts,
-             avoid_classes=_avoid_classes):
+def autolink(el, link_regexes=None,
+             avoid_elements=None,
+             avoid_hosts=None,
+             avoid_classes=None):
     """
     Turn any URLs into links.
 
@@ -556,6 +556,14 @@ def autolink(el, link_regexes=_link_regexes,
     If you pass in an element, the element's tail will not be
     substituted, only the contents of the element.
     """
+    if link_regexes is None:
+        link_regexes = _link_regexes
+    if avoid_elements is None:
+        avoid_elements = _avoid_elements
+    if avoid_hosts is None:
+        avoid_hosts = _avoid_hosts
+    if avoid_classes is None:
+        avoid_classes = _avoid_classes
     if el.tag in avoid_elements:
         return
     class_name = el.get('class')
@@ -660,8 +668,8 @@ _avoid_word_break_elements = ['pre', 'textarea', 'code']
 _avoid_word_break_classes = ['nobreak']
 
 def word_break(el, max_width=40,
-               avoid_elements=_avoid_word_break_elements,
-               avoid_classes=_avoid_word_break_classes,
+               avoid_elements=None,
+               avoid_classes=None,
                break_character=unichr(0x200b)):
     """
     Breaks any long words found in the body of the text (not attributes).
@@ -678,6 +686,10 @@ def word_break(el, max_width=40,
     """
     # Character suggestion of &#8203 comes from:
     #   http://www.cs.tut.fi/~jkorpela/html/nobr.html
+    if avoid_elements is None:
+        avoid_elements = _avoid_word_break_elements
+    if avoid_classes is None:
+        avoid_classes = _avoid_word_break_classes
     if el.tag in _avoid_word_break_elements:
         return
     class_name = el.get('class')

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -207,7 +207,7 @@ class Cleaner(object):
     safe_attrs = defs.safe_attrs
     add_nofollow = False
     host_whitelist = ()
-    whitelist_tags = set(['iframe', 'embed'])
+    whitelist_tags = {'iframe', 'embed'}
 
     def __init__(self, **kw):
         for name, value in kw.items():

--- a/src/lxml/html/diff.py
+++ b/src/lxml/html/diff.py
@@ -621,7 +621,7 @@ def fixup_chunks(chunks):
                     % (cur_word, result, chunk, chunks))
                 cur_word.post_tags.append(chunk)
         else:
-            assert 0
+            assert False
 
     if not result:
         return [token('', pre_tags=tag_accum)]

--- a/src/lxml/html/diff.py
+++ b/src/lxml/html/diff.py
@@ -621,7 +621,7 @@ def fixup_chunks(chunks):
                     % (cur_word, result, chunk, chunks))
                 cur_word.post_tags.append(chunk)
         else:
-            assert(0)
+            assert 0
 
     if not result:
         return [token('', pre_tags=tag_accum)]

--- a/src/lxml/html/diff.py
+++ b/src/lxml/html/diff.py
@@ -799,7 +799,6 @@ def _move_el_inside_block(el, tag):
         if _contains_block_level_tag(child):
             break
     else:
-        import sys
         # No block-level tags in any child
         children_tag = etree.Element(tag)
         children_tag.text = el.text

--- a/src/lxml/html/tests/test_autolink.py
+++ b/src/lxml/html/tests/test_autolink.py
@@ -3,8 +3,7 @@ from lxml.tests.common_imports import make_doctest
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_autolink.txt')])
+    suite.addTests([make_doctest('test_autolink.txt')])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/html/tests/test_autolink.py
+++ b/src/lxml/html/tests/test_autolink.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
 
 def test_suite():

--- a/src/lxml/html/tests/test_basic.py
+++ b/src/lxml/html/tests/test_basic.py
@@ -4,8 +4,7 @@ import lxml.html
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_basic.txt')])
+    suite.addTests([make_doctest('test_basic.txt')])
     suite.addTests([doctest.DocTestSuite(lxml.html)])
     return suite
 

--- a/src/lxml/html/tests/test_basic.py
+++ b/src/lxml/html/tests/test_basic.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest, doctest
 import lxml.html
 

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -73,7 +73,6 @@ class CleanerTest(unittest.TestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([make_doctest('test_clean.txt')])
-    if LIBXML_VERSION >= (2,6,31):
-        suite.addTests([make_doctest('test_clean_embed.txt')])
+    suite.addTests([make_doctest('test_clean_embed.txt')])
     suite.addTests(unittest.makeSuite(CleanerTest))
     return suite

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -72,9 +72,8 @@ class CleanerTest(unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_clean.txt')])
-        if LIBXML_VERSION >= (2,6,31):
-            suite.addTests([make_doctest('test_clean_embed.txt')])
+    suite.addTests([make_doctest('test_clean.txt')])
+    if LIBXML_VERSION >= (2,6,31):
+        suite.addTests([make_doctest('test_clean_embed.txt')])
     suite.addTests(unittest.makeSuite(CleanerTest))
     return suite

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -1,6 +1,5 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
-from lxml.etree import LIBXML_VERSION
 
 import lxml.html
 from lxml.html.clean import Cleaner, clean_html

--- a/src/lxml/html/tests/test_diff.py
+++ b/src/lxml/html/tests/test_diff.py
@@ -5,9 +5,8 @@ from lxml.html import diff
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_diff.txt'),
-                        doctest.DocTestSuite(diff)])
+    suite.addTests([make_doctest('test_diff.txt'),
+                    doctest.DocTestSuite(diff)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/html/tests/test_diff.py
+++ b/src/lxml/html/tests/test_diff.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest, doctest
 
 from lxml.html import diff

--- a/src/lxml/html/tests/test_feedparser_data.py
+++ b/src/lxml/html/tests/test_feedparser_data.py
@@ -8,8 +8,7 @@ except ImportError:
     from email import message_from_file as Message
 import unittest
 from lxml.tests.common_imports import doctest
-if sys.version_info >= (2,4):
-    from lxml.doctestcompare import LHTMLOutputChecker
+from lxml.doctestcompare import LHTMLOutputChecker
 
 from lxml.html.clean import clean, Cleaner
 
@@ -83,16 +82,15 @@ class FeedTestCase(unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        for dir in feed_dirs:
-            for fn in os.listdir(dir):
-                fn = os.path.join(dir, fn)
-                if fn.endswith('.data'):
-                    case = FeedTestCase(fn)
-                    suite.addTests([case])
-                    # This is my lazy way of stopping on first error:
-                    try:
-                        case.runTest()
-                    except:
-                        break
+    for dir in feed_dirs:
+        for fn in os.listdir(dir):
+            fn = os.path.join(dir, fn)
+            if fn.endswith('.data'):
+                case = FeedTestCase(fn)
+                suite.addTests([case])
+                # This is my lazy way of stopping on first error:
+                try:
+                    case.runTest()
+                except:
+                    break
     return suite

--- a/src/lxml/html/tests/test_feedparser_data.py
+++ b/src/lxml/html/tests/test_feedparser_data.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import re
 try:

--- a/src/lxml/html/tests/test_formfill.py
+++ b/src/lxml/html/tests/test_formfill.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
 
 def test_suite():

--- a/src/lxml/html/tests/test_formfill.py
+++ b/src/lxml/html/tests/test_formfill.py
@@ -3,6 +3,5 @@ from lxml.tests.common_imports import make_doctest
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_formfill.txt')])
+    suite.addTests([make_doctest('test_formfill.txt')])
     return suite

--- a/src/lxml/html/tests/test_forms.py
+++ b/src/lxml/html/tests/test_forms.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
 
 def test_suite():

--- a/src/lxml/html/tests/test_forms.py
+++ b/src/lxml/html/tests/test_forms.py
@@ -3,8 +3,7 @@ from lxml.tests.common_imports import make_doctest
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_forms.txt')])
+    suite.addTests([make_doctest('test_forms.txt')])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/html/tests/test_html5parser.py
+++ b/src/lxml/html/tests/test_html5parser.py
@@ -7,23 +7,9 @@ except ImportError:                     # python 3
 import sys
 import tempfile
 import unittest
-try:
-    from unittest import skipUnless
-except ImportError:
-    # sys.version < (2, 7)
-    def skipUnless(condition, reason):
-        return lambda f: condition and f or None
+from unittest import skipUnless
 
-if sys.version_info < (2,6):
-    class NamedTemporaryFile(object):
-        def __init__(self, delete=True, **kwargs):
-            self._tmpfile = tempfile.NamedTemporaryFile(**kwargs)
-        def close(self):
-            self._tmpfile.flush()
-        def __getattr__(self, name):
-            return getattr(self._tmpfile, name)
-else:
-    NamedTemporaryFile = tempfile.NamedTemporaryFile
+NamedTemporaryFile = tempfile.NamedTemporaryFile
 
 from lxml.builder import ElementMaker
 from lxml.etree import Element, ElementTree, ParserError

--- a/src/lxml/html/tests/test_html5parser.py
+++ b/src/lxml/html/tests/test_html5parser.py
@@ -9,8 +9,6 @@ import tempfile
 import unittest
 from unittest import skipUnless
 
-NamedTemporaryFile = tempfile.NamedTemporaryFile
-
 from lxml.builder import ElementMaker
 from lxml.etree import Element, ElementTree, ParserError
 from lxml.html import html_parser, XHTML_NAMESPACE
@@ -304,7 +302,7 @@ class Test_parse(unittest.TestCase):
         return parse(*args, **kwargs)
 
     def make_temp_file(self, contents=''):
-        tmpfile = NamedTemporaryFile(delete=False)
+        tmpfile = tempfile.NamedTemporaryFile(delete=False)
         try:
             tmpfile.write(contents.encode('utf8'))
             tmpfile.flush()

--- a/src/lxml/html/tests/test_rewritelinks.py
+++ b/src/lxml/html/tests/test_rewritelinks.py
@@ -1,4 +1,4 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
 
 def test_suite():

--- a/src/lxml/html/tests/test_rewritelinks.py
+++ b/src/lxml/html/tests/test_rewritelinks.py
@@ -3,8 +3,7 @@ from lxml.tests.common_imports import make_doctest
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([make_doctest('test_rewritelinks.txt')])
+    suite.addTests([make_doctest('test_rewritelinks.txt')])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/html/tests/test_select.py
+++ b/src/lxml/html/tests/test_select.py
@@ -39,7 +39,7 @@ class SelectTest(unittest.TestCase):
     def test_multiple_select_value_multiple_selected_options(self):
         self.assertEqual(
             self._evaluate_select([('a', True), ('b', True)], multiple=True),
-            set(['a', 'b']))
+            {'a', 'b'})
 
 
 def test_suite():

--- a/src/lxml/html/tests/test_xhtml.py
+++ b/src/lxml/html/tests/test_xhtml.py
@@ -1,6 +1,5 @@
-import unittest, sys
+import unittest
 from lxml.tests.common_imports import make_doctest
-import lxml.html
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/html/tests/transform_feedparser_data.py
+++ b/src/lxml/html/tests/transform_feedparser_data.py
@@ -105,6 +105,5 @@ def translate_all(dir):
             translate_file(fn)
         
 if __name__ == '__main__':
-    import sys
     translate_all(os.path.join(os.path.dirname(__file__), 'feedparser-data'))
 

--- a/src/lxml/includes/etree_defs.h
+++ b/src/lxml/includes/etree_defs.h
@@ -6,8 +6,8 @@
 #ifndef PY_VERSION_HEX
 #  error the development package of Python (header files etc.) is not installed correctly
 #else
-#  if PY_VERSION_HEX < 0x02060000 || PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x03020000
-#  error this version of lxml requires Python 2.6, 2.7, 3.2 or later
+#  if PY_VERSION_HEX < 0x02070000 || PY_MAJOR_VERSION >= 3 && PY_VERSION_HEX < 0x03030000
+#  error this version of lxml requires Python 2.7, 3.3 or later
 #  endif
 #endif
 
@@ -262,8 +262,6 @@ long _ftol2( double dblSource ) { return _ftol( dblSource ); }
         (((c_node)->ns == 0) ? 0 : ((c_node)->ns->href))
 
 
-/* PyCapsule was added in Py2.7 */
-#if PY_VERSION_HEX >= 0x02070000
 #include "string.h"
 static void* lxml_unpack_xmldoc_capsule(PyObject* capsule, int* is_owned) {
     xmlDoc *c_doc;
@@ -301,9 +299,6 @@ static void* lxml_unpack_xmldoc_capsule(PyObject* capsule, int* is_owned) {
     }
     return c_doc;
 }
-#else
-#  define lxml_unpack_xmldoc_capsule(capsule, is_owned)  ((((void)capsule, 0) || ((void)is_owned, 0)) ? NULL : NULL)
-#endif
 
 /* Macro pair implementation of a depth first tree walker
  *

--- a/src/lxml/isoschematron/__init__.py
+++ b/src/lxml/isoschematron/__init__.py
@@ -232,11 +232,17 @@ class Schematron(_etree._Validator):
     _validation_errors = ASSERTS_ONLY
 
     def __init__(self, etree=None, file=None, include=True, expand=True,
-                 include_params={}, expand_params={}, compile_params={},
+                 include_params=None, expand_params=None, compile_params=None,
                  store_schematron=False, store_xslt=False, store_report=False,
                  phase=None, error_finder=ASSERTS_ONLY):
         super(Schematron, self).__init__()
 
+        if include_params is None:
+            include_params = {}
+        if expand_params is None:
+            expand_params = {}
+        if compile_params is None:
+            compile_params = {}
         self._store_report = store_report
         self._schematron = None
         self._validator_xslt = None

--- a/src/lxml/isoschematron/__init__.py
+++ b/src/lxml/isoschematron/__init__.py
@@ -232,17 +232,11 @@ class Schematron(_etree._Validator):
     _validation_errors = ASSERTS_ONLY
 
     def __init__(self, etree=None, file=None, include=True, expand=True,
-                 include_params=None, expand_params=None, compile_params=None,
+                 include_params={}, expand_params={}, compile_params={},
                  store_schematron=False, store_xslt=False, store_report=False,
                  phase=None, error_finder=ASSERTS_ONLY):
         super(Schematron, self).__init__()
 
-        if include_params is None:
-            include_params = {}
-        if expand_params is None:
-            expand_params = {}
-        if compile_params is None:
-            compile_params = {}
         self._store_report = store_report
         self._schematron = None
         self._validator_xslt = None

--- a/src/lxml/objectify.pyx
+++ b/src/lxml/objectify.pyx
@@ -76,7 +76,7 @@ PYTYPE_ATTRIBUTE = None
 cdef unicode TREE_PYTYPE_NAME = u"TREE"
 
 cdef tuple _unicodeAndUtf8(s):
-    return (s, python.PyUnicode_AsUTF8String(s))
+    return s, python.PyUnicode_AsUTF8String(s)
 
 def set_pytype_attribute_tag(attribute_tag=None):
     u"""set_pytype_attribute_tag(attribute_tag=None)
@@ -159,7 +159,7 @@ cdef class ObjectifiedElement(ElementBase):
 
     # pickle support for objectified Element
     def __reduce__(self):
-        return (fromstring, (etree.tostring(self),))
+        return fromstring, (etree.tostring(self),)
 
     property text:
         def __get__(self):
@@ -1359,7 +1359,7 @@ cdef _setupPickle(elementTreeReduceFunction):
                    elementTreeReduceFunction, __unpickleElementTree)
 
 def pickleReduceElementTree(obj):
-    return (__unpickleElementTree, (etree.tostring(obj),))
+    return __unpickleElementTree, (etree.tostring(obj),)
 
 _setupPickle(pickleReduceElementTree)
 del pickleReduceElementTree

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -628,10 +628,10 @@ cdef int _raiseParseError(xmlparser.xmlParserCtxt* ctxt, filename,
                 <bytes>filename, len(<bytes>filename))
         if ctxt.lastError.message is not NULL:
             try:
-                message = (ctxt.lastError.message).decode('utf-8')
+                message = ctxt.lastError.message.decode('utf-8')
             except UnicodeDecodeError:
                 # the filename may be in there => play it safe
-                message = (ctxt.lastError.message).decode('iso8859-1')
+                message = ctxt.lastError.message.decode('iso8859-1')
             message = f"Error reading file '{filename}': {message.strip()}"
         else:
             message = f"Error reading '{filename}'"
@@ -640,7 +640,7 @@ cdef int _raiseParseError(xmlparser.xmlParserCtxt* ctxt, filename,
         raise error_log._buildParseException(
             XMLSyntaxError, u"Document is not well formed")
     elif ctxt.lastError.message is not NULL:
-        message = (ctxt.lastError.message).strip()
+        message = ctxt.lastError.message.strip()
         code = ctxt.lastError.code
         line = ctxt.lastError.line
         column = ctxt.lastError.int2

--- a/src/lxml/python.pxd
+++ b/src/lxml/python.pxd
@@ -29,7 +29,7 @@ cdef extern from "Python.h":
                                          char* encoding, char* errors)
     cdef cython.unicode PyUnicode_DecodeUTF8(char* s, Py_ssize_t size, char* errors)
     cdef cython.unicode PyUnicode_DecodeLatin1(char* s, Py_ssize_t size, char* errors)
-    cdef object PyUnicode_RichCompare(object o1, object o2, int op)  # not in Py2.4
+    cdef object PyUnicode_RichCompare(object o1, object o2, int op)
     cdef bytes PyUnicode_AsUTF8String(object ustring)
     cdef bytes PyUnicode_AsASCIIString(object ustring)
     cdef char* PyUnicode_AS_DATA(object ustring)

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -25,7 +25,7 @@ def _getNsTag(tag):
     if tag[0] == '{':
         return tuple(tag[1:].split('}', 1))
     else:
-        return (None, tag)
+        return None, tag
 
 
 class ElementTreeContentHandler(ContentHandler):

--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -418,15 +418,15 @@ cdef unsigned char *xmlSerializeHexCharRef(unsigned char *out, int val):
     out[0] = 'x'
     out += 1
 
-    if (val < 0x10):
+    if val < 0x10:
         ptr = out
-    elif (val < 0x100):
+    elif val < 0x100:
         ptr = out + 1
-    elif (val < 0x1000):
+    elif val < 0x1000:
         ptr = out + 2
-    elif (val < 0x10000):
+    elif val < 0x10000:
         ptr = out + 3
-    elif (val < 0x100000):
+    elif val < 0x100000:
         ptr = out + 4
     else:
         ptr = out + 5
@@ -495,56 +495,56 @@ cdef _write_attr_string(tree.xmlOutputBuffer* buf, const char *string):
         return
 
     base = cur = <const char*>string
-    while (cur[0] != 0):
-        if (cur[0] == '\n'):
-            if (base != cur):
+    while cur[0] != 0:
+        if cur[0] == '\n':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 5, "&#10;")
             cur += 1
             base = cur
 
-        elif (cur[0] == '\r'):
-            if (base != cur):
+        elif cur[0] == '\r':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 5, "&#13;")
             cur += 1
             base = cur
 
-        elif (cur[0] == '\t'):
-            if (base != cur):
+        elif cur[0] == '\t':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 4, "&#9;")
             cur += 1
             base = cur
 
-        elif (cur[0] == '"'):
-            if (base != cur):
+        elif cur[0] == '"':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 6, "&quot;")
             cur += 1
             base = cur
 
-        elif (cur[0] == '<'):
-            if (base != cur):
+        elif cur[0] == '<':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 4, "&lt;")
             cur += 1
             base = cur
 
-        elif (cur[0] == '>'):
-            if (base != cur):
+        elif cur[0] == '>':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 4, "&gt;")
             cur += 1
             base = cur
-        elif (cur[0] == '&'):
-            if (base != cur):
+        elif cur[0] == '&':
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             tree.xmlOutputBufferWrite(buf, 5, "&amp;")
@@ -553,23 +553,23 @@ cdef _write_attr_string(tree.xmlOutputBuffer* buf, const char *string):
 
         elif (<const unsigned char>cur[0] >= 0x80) and (cur[1] != 0):
 
-            if (base != cur):
+            if base != cur:
                 tree.xmlOutputBufferWrite(buf, cur - base, base)
 
             ucur = <const unsigned char *>cur
 
-            if (ucur[0] < 0xC0):
+            if ucur[0] < 0xC0:
                 # invalid UTF-8 sequence
                 val = ucur[0]
                 l = 1
 
-            elif (ucur[0] < 0xE0):
+            elif ucur[0] < 0xE0:
                 val = (ucur[0]) & 0x1F
                 val <<= 6
                 val |= (ucur[1]) & 0x3F
                 l = 2
 
-            elif ((ucur[0] < 0xF0) and (ucur[2] != 0)):
+            elif (ucur[0] < 0xF0) and (ucur[2] != 0):
                 val = (ucur[0]) & 0x0F
                 val <<= 6
                 val |= (ucur[1]) & 0x3F
@@ -577,7 +577,7 @@ cdef _write_attr_string(tree.xmlOutputBuffer* buf, const char *string):
                 val |= (ucur[2]) & 0x3F
                 l = 3
 
-            elif ((ucur[0] < 0xF8) and (ucur[2] != 0) and (ucur[3] != 0)):
+            elif (ucur[0] < 0xF8) and (ucur[2] != 0) and (ucur[3] != 0):
                 val = (ucur[0]) & 0x07
                 val <<= 6
                 val |= (ucur[1]) & 0x3F
@@ -591,7 +591,7 @@ cdef _write_attr_string(tree.xmlOutputBuffer* buf, const char *string):
                 val = ucur[0]
                 l = 1
 
-            if ((l == 1) or (not tree.xmlIsCharQ(val))):
+            if (l == 1) or (not tree.xmlIsCharQ(val)):
                 raise ValueError(f"Invalid character: {val:X}")
 
             # We could do multiple things here. Just save
@@ -604,7 +604,7 @@ cdef _write_attr_string(tree.xmlOutputBuffer* buf, const char *string):
         else:
             cur += 1
 
-    if (base != cur):
+    if base != cur:
         tree.xmlOutputBufferWrite(buf, cur - base, base)
 
 

--- a/src/lxml/tests/dummy_http_server.py
+++ b/src/lxml/tests/dummy_http_server.py
@@ -1,5 +1,5 @@
 """
-Simple HTTP request dumper for tests in Python 2.5+.
+Simple HTTP request dumper for tests.
 """
 
 import sys

--- a/src/lxml/tests/selftest.py
+++ b/src/lxml/tests/selftest.py
@@ -823,7 +823,8 @@ def xpath_tokenizer(p):
 #
 # xinclude tests (samples from appendix C of the xinclude specification)
 
-XINCLUDE = {"C1.xml": """\
+XINCLUDE = {
+    "C1.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>120 Mz is adequate for an average home user.</p>
@@ -836,7 +837,8 @@ XINCLUDE = {"C1.xml": """\
   and should not be interpreted as official policy endorsed by this
   organization.</p>
 </disclaimer>
-""", "C2.xml": """\
+""",
+    "C2.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>This document has been accessed
@@ -853,7 +855,8 @@ XINCLUDE = {"C1.xml": """\
 <data>
   <item><![CDATA[Brooks & Shields]]></item>
 </data>
-""", "C5.xml": """\
+""",
+    "C5.xml": """\
 <?xml version='1.0'?>
 <div xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="example.txt" parse="text">
@@ -864,7 +867,8 @@ XINCLUDE = {"C1.xml": """\
     </xi:fallback>
   </xi:include>
 </div>
-""", "default.xml": """\
+""",
+    "default.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>Example.</p>

--- a/src/lxml/tests/selftest.py
+++ b/src/lxml/tests/selftest.py
@@ -823,51 +823,37 @@ def xpath_tokenizer(p):
 #
 # xinclude tests (samples from appendix C of the xinclude specification)
 
-XINCLUDE = {}
-
-XINCLUDE["C1.xml"] = """\
+XINCLUDE = {"C1.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>120 Mz is adequate for an average home user.</p>
   <xi:include href="disclaimer.xml"/>
 </document>
-"""
-
-XINCLUDE["disclaimer.xml"] = """\
+""", "disclaimer.xml": """\
 <?xml version='1.0'?>
 <disclaimer>
   <p>The opinions represented herein represent those of the individual
   and should not be interpreted as official policy endorsed by this
   organization.</p>
 </disclaimer>
-"""
-
-XINCLUDE["C2.xml"] = """\
+""", "C2.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>This document has been accessed
   <xi:include href="count.txt" parse="text"/> times.</p>
 </document>
-"""
-
-XINCLUDE["count.txt"] = "324387"
-
-XINCLUDE["C3.xml"] = """\
+""", "count.txt": "324387", "C3.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>The following is the source of the "data.xml" resource:</p>
   <example><xi:include href="data.xml" parse="text"/></example>
 </document>
-"""
-
-XINCLUDE["data.xml"] = """\
+""", "data.xml": """\
 <?xml version='1.0'?>
 <data>
   <item><![CDATA[Brooks & Shields]]></item>
 </data>
-"""
-
-XINCLUDE["C5.xml"] = """\
+""", "C5.xml": """\
 <?xml version='1.0'?>
 <div xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="example.txt" parse="text">
@@ -878,15 +864,14 @@ XINCLUDE["C5.xml"] = """\
     </xi:fallback>
   </xi:include>
 </div>
-"""
-
-XINCLUDE["default.xml"] = """\
+""", "default.xml": """\
 <?xml version='1.0'?>
 <document xmlns:xi="http://www.w3.org/2001/XInclude">
   <p>Example.</p>
   <xi:include href="samples/simple.xml"/>
 </document>
-"""
+"""}
+
 
 def xinclude_loader(href, parse="xml", encoding=None):
     try:

--- a/src/lxml/tests/selftest2.py
+++ b/src/lxml/tests/selftest2.py
@@ -102,9 +102,9 @@ def check_element(element):
         print("no tail member")
     check_string(element.tag)
     check_mapping(element.attrib)
-    if element.text != None:
+    if element.text is not None:
         check_string(element.text)
-    if element.tail != None:
+    if element.tail is not None:
         check_string(element.tail)
 
 def check_element_tree(tree):

--- a/src/lxml/tests/test_doctestcompare.py
+++ b/src/lxml/tests/test_doctestcompare.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from lxml import etree

--- a/src/lxml/tests/test_doctestcompare.py
+++ b/src/lxml/tests/test_doctestcompare.py
@@ -123,8 +123,7 @@ class DoctestCompareTest(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    if sys.version_info >= (2,4):
-        suite.addTests([unittest.makeSuite(DoctestCompareTest)])
+    suite.addTests([unittest.makeSuite(DoctestCompareTest)])
     return suite
 
 

--- a/src/lxml/tests/test_elementtree.py
+++ b/src/lxml/tests/test_elementtree.py
@@ -3929,9 +3929,9 @@ class _ETreeTestCaseBase(HelperTestCase):
         self.assertTrue(hasattr(element, 'tail'))
         self._check_string(element.tag)
         self._check_mapping(element.attrib)
-        if element.text != None:
+        if element.text is not None:
             self._check_string(element.text)
-        if element.tail != None:
+        if element.tail is not None:
             self._check_string(element.tail)
         
     def _check_string(self, string):

--- a/src/lxml/tests/test_elementtree.py
+++ b/src/lxml/tests/test_elementtree.py
@@ -4101,7 +4101,7 @@ class _XMLPullParserTest(unittest.TestCase):
 
     def test_events_sequence(self):
         # Test that events can be some sequence that's not just a tuple or list
-        eventset = set(['end', 'start'])
+        eventset = {'end', 'start'}
         parser = self.etree.XMLPullParser(events=eventset)
         self._feed(parser, "<foo>bar</foo>")
         self.assert_event_tags(parser, [('start', 'foo'), ('end', 'foo')])

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -697,7 +697,7 @@ class ETreeOnlyTestCase(HelperTestCase):
 
         def name(event, el):
             if event == 'pi':
-                return (el.target, el.text)
+                return el.target, el.text
             else:
                 return el.tag
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1503,42 +1503,41 @@ class ETreeOnlyTestCase(HelperTestCase):
         xml = '<!DOCTYPE doc SYSTEM "test"><doc>&myentity;</doc>'
         self.assertRaises(_LocalException, parse, BytesIO(xml), parser)
 
-    if etree.LIBXML_VERSION > (2,6,20):
-        def test_entity_parse(self):
-            parse = self.etree.parse
-            tostring = self.etree.tostring
-            parser = self.etree.XMLParser(resolve_entities=False)
-            Entity = self.etree.Entity
+    def test_entity_parse(self):
+        parse = self.etree.parse
+        tostring = self.etree.tostring
+        parser = self.etree.XMLParser(resolve_entities=False)
+        Entity = self.etree.Entity
 
-            xml = _bytes('<!DOCTYPE doc SYSTEM "test"><doc>&myentity;</doc>')
-            tree = parse(BytesIO(xml), parser)
-            root = tree.getroot()
-            self.assertEqual(root[0].tag, Entity)
-            self.assertEqual(root[0].text, "&myentity;")
-            self.assertEqual(root[0].tail, None)
-            self.assertEqual(root[0].name, "myentity")
+        xml = _bytes('<!DOCTYPE doc SYSTEM "test"><doc>&myentity;</doc>')
+        tree = parse(BytesIO(xml), parser)
+        root = tree.getroot()
+        self.assertEqual(root[0].tag, Entity)
+        self.assertEqual(root[0].text, "&myentity;")
+        self.assertEqual(root[0].tail, None)
+        self.assertEqual(root[0].name, "myentity")
 
-            self.assertEqual(_bytes('<doc>&myentity;</doc>'),
-                              tostring(root))
+        self.assertEqual(_bytes('<doc>&myentity;</doc>'),
+                          tostring(root))
 
-        def test_entity_restructure(self):
-            xml = _bytes('''<!DOCTYPE root [ <!ENTITY nbsp "&#160;"> ]>
-                <root>
-                  <child1/>
-                  <child2/>
-                  <child3>&nbsp;</child3>
-                </root>''')
+    def test_entity_restructure(self):
+        xml = _bytes('''<!DOCTYPE root [ <!ENTITY nbsp "&#160;"> ]>
+            <root>
+              <child1/>
+              <child2/>
+              <child3>&nbsp;</child3>
+            </root>''')
 
-            parser = self.etree.XMLParser(resolve_entities=False)
-            root = etree.fromstring(xml, parser)
-            self.assertEqual([ el.tag for el in root ],
-                              ['child1', 'child2', 'child3'])
+        parser = self.etree.XMLParser(resolve_entities=False)
+        root = etree.fromstring(xml, parser)
+        self.assertEqual([ el.tag for el in root ],
+                          ['child1', 'child2', 'child3'])
 
-            root[0] = root[-1]
-            self.assertEqual([ el.tag for el in root ],
-                              ['child3', 'child2'])
-            self.assertEqual(root[0][0].text, '&nbsp;')
-            self.assertEqual(root[0][0].name, 'nbsp')
+        root[0] = root[-1]
+        self.assertEqual([ el.tag for el in root ],
+                          ['child3', 'child2'])
+        self.assertEqual(root[0][0].text, '&nbsp;')
+        self.assertEqual(root[0][0].name, 'nbsp')
 
     def test_entity_append(self):
         Entity = self.etree.Entity

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -4613,10 +4613,8 @@ def test_suite():
     suite.addTests(doctest.DocTestSuite(etree))
     suite.addTests(
         [make_doctest('../../../doc/tutorial.txt')])
-    if sys.version_info >= (2,6):
-        # now requires the 'with' statement
-        suite.addTests(
-            [make_doctest('../../../doc/api.txt')])
+    suite.addTests(
+        [make_doctest('../../../doc/api.txt')])
     suite.addTests(
         [make_doctest('../../../doc/FAQ.txt')])
     suite.addTests(

--- a/src/lxml/tests/test_external_document.py
+++ b/src/lxml/tests/test_external_document.py
@@ -14,8 +14,6 @@ DOC_NAME = b'libxml2:xmlDoc'
 DESTRUCTOR_NAME = b'destructor:xmlFreeDoc'
 
 
-@skipIf(sys.version_info[:2] < (2, 7),
-        'Not supported for python < 2.7')
 class ExternalDocumentTestCase(HelperTestCase):
     def setUp(self):
         import ctypes

--- a/src/lxml/tests/test_external_document.py
+++ b/src/lxml/tests/test_external_document.py
@@ -5,10 +5,9 @@ Test cases related to direct loading of external libxml2 documents
 
 from __future__ import absolute_import
 
-import sys
 import unittest
 
-from .common_imports import HelperTestCase, etree, skipIf
+from .common_imports import HelperTestCase, etree
 
 DOC_NAME = b'libxml2:xmlDoc'
 DESTRUCTOR_NAME = b'destructor:xmlFreeDoc'

--- a/src/lxml/tests/test_http_io.py
+++ b/src/lxml/tests/test_http_io.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-Web IO test cases that need Python 2.5+ (wsgiref)
+Web IO test cases (wsgiref)
 """
 
 from __future__ import with_statement

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -82,7 +82,7 @@ class _XmlFileTestCaseBase(HelperTestCase):
         tree = self._parse_file()
         self.assertTrue(tree is not None)
         self.assertEqual(100, len(tree.getroot()))
-        self.assertEqual({'test'}, set(el.tag for el in tree.getroot()))
+        self.assertEqual({'test'}, {el.tag for el in tree.getroot()})
 
     def test_namespace_nsmap(self):
         with etree.xmlfile(self._file) as xf:

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -440,9 +440,9 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
 
     def test_void_elements(self):
         # http://www.w3.org/TR/html5/syntax.html#elements-0
-        void_elements = {"area", "base", "br", "col", "embed", "hr", "img",
-                         "input", "keygen", "link", "meta", "param", "source",
-                         "track", "wbr"}
+        void_elements = {
+            "area", "base", "br", "col", "embed", "hr", "img", "input",
+            "keygen", "link", "meta", "param", "source", "track", "wbr"}
 
         # FIXME: These don't get serialized as void elements.
         void_elements.difference_update([

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -82,7 +82,7 @@ class _XmlFileTestCaseBase(HelperTestCase):
         tree = self._parse_file()
         self.assertTrue(tree is not None)
         self.assertEqual(100, len(tree.getroot()))
-        self.assertEqual(set(['test']), set(el.tag for el in tree.getroot()))
+        self.assertEqual({'test'}, set(el.tag for el in tree.getroot()))
 
     def test_namespace_nsmap(self):
         with etree.xmlfile(self._file) as xf:
@@ -440,11 +440,9 @@ class HtmlFileTestCase(_XmlFileTestCaseBase):
 
     def test_void_elements(self):
         # http://www.w3.org/TR/html5/syntax.html#elements-0
-        void_elements = set([
-            "area", "base", "br", "col", "embed", "hr", "img",
-            "input", "keygen", "link", "meta", "param",
-            "source", "track", "wbr"
-        ])
+        void_elements = {"area", "base", "br", "col", "embed", "hr", "img",
+                         "input", "keygen", "link", "meta", "param", "source",
+                         "track", "wbr"}
 
         # FIXME: These don't get serialized as void elements.
         void_elements.difference_update([

--- a/src/lxml/tests/test_io.py
+++ b/src/lxml/tests/test_io.py
@@ -15,16 +15,7 @@ from common_imports import etree, ElementTree, _str, _bytes
 from common_imports import SillyFileLike, LargeFileLike, HelperTestCase
 from common_imports import read_file, write_to_file, BytesIO
 
-if sys.version_info < (2,6):
-    class NamedTemporaryFile(object):
-        def __init__(self, delete=True, **kwargs):
-            self._tmpfile = tempfile.NamedTemporaryFile(**kwargs)
-        def close(self):
-            self._tmpfile.flush()
-        def __getattr__(self, name):
-            return getattr(self._tmpfile, name)
-else:
-    NamedTemporaryFile = tempfile.NamedTemporaryFile
+NamedTemporaryFile = tempfile.NamedTemporaryFile
 
 
 class _IOTestCaseBase(HelperTestCase):

--- a/src/lxml/tests/test_io.py
+++ b/src/lxml/tests/test_io.py
@@ -15,8 +15,6 @@ from common_imports import etree, ElementTree, _str, _bytes
 from common_imports import SillyFileLike, LargeFileLike, HelperTestCase
 from common_imports import read_file, write_to_file, BytesIO
 
-NamedTemporaryFile = tempfile.NamedTemporaryFile
-
 
 class _IOTestCaseBase(HelperTestCase):
     """(c)ElementTree compatibility for IO functions/methods
@@ -276,7 +274,7 @@ class _IOTestCaseBase(HelperTestCase):
         bom = _bytes('\\xEF\\xBB\\xBF').decode(
             "unicode_escape").encode("latin1")
         self.assertEqual(3, len(bom))
-        f = NamedTemporaryFile(delete=False)
+        f = tempfile.NamedTemporaryFile(delete=False)
         try:
             try:
                 f.write(bom)
@@ -294,7 +292,7 @@ class _IOTestCaseBase(HelperTestCase):
         bom = _bytes('\\xEF\\xBB\\xBF').decode(
             "unicode_escape").encode("latin1")
         self.assertEqual(3, len(bom))
-        f = NamedTemporaryFile(delete=False)
+        f = tempfile.NamedTemporaryFile(delete=False)
         try:
             try:
                 f.write(bom)
@@ -317,7 +315,7 @@ class _IOTestCaseBase(HelperTestCase):
         xml = uxml.encode("utf-16")
         self.assertTrue(xml[:2] in boms, repr(xml[:2]))
 
-        f = NamedTemporaryFile(delete=False)
+        f = tempfile.NamedTemporaryFile(delete=False)
         try:
             try:
                 f.write(xml)

--- a/src/lxml/tests/test_isoschematron.py
+++ b/src/lxml/tests/test_isoschematron.py
@@ -269,7 +269,7 @@ class ETreeISOSchematronTestCase(HelperTestCase):
         self.assertTrue(
             isinstance(schematron.validation_report, etree._ElementTree),
             'expected a validation report result tree, got: %s' %
-            (schematron.validation_report))
+            schematron.validation_report)
 
         schematron = isoschematron.Schematron(schema, store_report=False)
         self.assertTrue(schematron(tree_valid), schematron.error_log)
@@ -277,7 +277,7 @@ class ETreeISOSchematronTestCase(HelperTestCase):
         self.assertTrue(not valid)
         self.assertTrue(schematron.validation_report is None,
             'validation reporting switched off, still: %s' %
-            (schematron.validation_report))
+                        schematron.validation_report)
 
     def test_schematron_store_schematron(self):
         schema = self.parse('''\

--- a/src/lxml/tests/test_isoschematron.py
+++ b/src/lxml/tests/test_isoschematron.py
@@ -268,16 +268,14 @@ class ETreeISOSchematronTestCase(HelperTestCase):
         self.assertTrue(not valid)
         self.assertTrue(
             isinstance(schematron.validation_report, etree._ElementTree),
-            'expected a validation report result tree, got: %s' %
-            schematron.validation_report)
+            'expected a validation report result tree, got: %s' % schematron.validation_report)
 
         schematron = isoschematron.Schematron(schema, store_report=False)
         self.assertTrue(schematron(tree_valid), schematron.error_log)
         valid = schematron(tree_invalid)
         self.assertTrue(not valid)
         self.assertTrue(schematron.validation_report is None,
-            'validation reporting switched off, still: %s' %
-                        schematron.validation_report)
+            'validation reporting switched off, still: %s' % schematron.validation_report)
 
     def test_schematron_store_schematron(self):
         schema = self.parse('''\

--- a/src/lxml/tests/test_objectify.py
+++ b/src/lxml/tests/test_objectify.py
@@ -462,7 +462,7 @@ class ObjectifyTestCase(HelperTestCase):
         self.assertEqual([root.c1],
                           list(iter(root.c1)))
         self.assertEqual([root.c1.c2[0], root.c1.c2[1], root.c1.c2[2]],
-                          list(iter((root.c1.c2))))
+                         list(iter(root.c1.c2)))
 
     def test_class_lookup(self):
         root = self.XML(xml_str)

--- a/src/lxml/tests/test_objectify.py
+++ b/src/lxml/tests/test_objectify.py
@@ -2621,9 +2621,7 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([unittest.makeSuite(ObjectifyTestCase)])
     suite.addTests(doctest.DocTestSuite(objectify))
-    if sys.version_info >= (2,4):
-        suite.addTests(
-            [make_doctest('../../../doc/objectify.txt')])
+    suite.addTests([make_doctest('../../../doc/objectify.txt')])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_pyclasslookup.py
+++ b/src/lxml/tests/test_pyclasslookup.py
@@ -5,7 +5,7 @@ Tests specific to the Python based class lookup.
 """
 
 
-import unittest, operator, os.path, sys
+import unittest, os.path, sys
 
 this_dir = os.path.dirname(__file__)
 if this_dir not in sys.path:

--- a/src/lxml/tests/test_threading.py
+++ b/src/lxml/tests/test_threading.py
@@ -514,7 +514,7 @@ class ThreadPipelineTestCase(HelperTestCase):
             last = worker_class(last.out_queue, item_count, **kwargs)
             last.setDaemon(True)
             last.start()
-        return (in_queue, start, last)
+        return in_queue, start, last
 
     def test_thread_pipeline_thread_parse(self):
         item_count = self.item_count

--- a/src/lxml/xmlid.pxi
+++ b/src/lxml/xmlid.pxi
@@ -19,7 +19,7 @@ def XMLID(text, parser=None, *, base_url=None):
     dic = {}
     for elem in _find_id_attributes(root):
         dic[elem.get(u'id')] = elem
-    return (root, dic)
+    return root, dic
 
 def XMLDTDID(text, parser=None, *, base_url=None):
     u"""XMLDTDID(text, parser=None, base_url=None)
@@ -37,9 +37,9 @@ def XMLDTDID(text, parser=None, *, base_url=None):
     root = XML(text, parser, base_url=base_url)
     # xml:id spec compatible implementation: use DTD ID attributes from libxml2
     if root._doc._c_doc.ids is NULL:
-        return (root, {})
+        return root, {}
     else:
-        return (root, _IDDict(root))
+        return root, _IDDict(root)
 
 def parseid(source, parser=None, *, base_url=None):
     u"""parseid(source, parser=None)
@@ -53,7 +53,7 @@ def parseid(source, parser=None, *, base_url=None):
     """
     cdef _Document doc
     doc = _parseDocument(source, parser, base_url)
-    return (_elementTreeFactory(doc, None), _IDDict(doc))
+    return _elementTreeFactory(doc, None), _IDDict(doc)
 
 cdef class _IDDict:
     u"""IDDict(self, etree)

--- a/test.py
+++ b/test.py
@@ -455,8 +455,8 @@ def main(argv):
     """Main program."""
 
     # Environment
-    if sys.version_info < (2, 6):
-        stderr('%s: need Python 2.6 or later' % argv[0])
+    if sys.version_info < (2, 7):
+        stderr('%s: need Python 2.7 or later' % argv[0])
         stderr('your python is %s' % sys.version)
         return 1
 

--- a/tools/manylinux/build-wheels.sh
+++ b/tools/manylinux/build-wheels.sh
@@ -35,8 +35,6 @@ assert_importable() {
 
 prepare_system() {
     #yum install -y zlib-devel
-    # Remove Python 2.6 symlinks
-    rm -f /opt/python/cp26*
     echo "Python versions found: $(cd /opt/python && echo cp* | sed -e 's|[^ ]*-||g')"
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py33, py34, py35, py36, py37
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34
+envlist = py27, py33, py34
 
 [testenv]
 setenv =


### PR DESCRIPTION
Support for Python 2.6 was officially removed in https://github.com/lxml/lxml/commit/9436948369d636d50355f7f679a0cfd7edc23044.

This removes some redundant code for Python 2.6 and earlier, and modernises some of the code using PyCharm's code inspections.