### PR TITLE
Fix index out of range when <body> or <head> is missing

### DIFF
--- a/src/lxml/html/__init__.py
+++ b/src/lxml/html/__init__.py
@@ -287,7 +287,9 @@ class HtmlMixin(object):
         Return the <body> element.  Can be called from a child element
         to get the document's head.
         """
-        return self.xpath('//body|//x:body', namespaces={'x':XHTML_NAMESPACE})[0]
+        result = self.xpath('//body|//x:body', namespaces={'x':XHTML_NAMESPACE})
+        if len(result) > 1:
+            return result[0]
 
     @property
     def head(self):
@@ -295,7 +297,9 @@ class HtmlMixin(object):
         Returns the <head> element.  Can be called from a child
         element to get the document's head.
         """
-        return self.xpath('//head|//x:head', namespaces={'x':XHTML_NAMESPACE})[0]
+        result = self.xpath('//head|//x:head', namespaces={'x':XHTML_NAMESPACE})
+        if len(result) > 1:
+            return result[0]
 
     @property
     def label(self):


### PR DESCRIPTION
If a HTML file that doesn't contain a <body> or <head> part is parsed, 
it can lead to a index out of range error when you try 
`getattr(lxmlElement, "body")`
