### PR TITLE
fixed reflected xss issiue in clean html

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -465,7 +465,7 @@ class Cleaner(object):
         bad = []
         self._kill_elements(
             doc, lambda el: _conditional_comment_re.search(el.text),
-            etree.Comment)                
+            etree.Comment)
 
     def _kill_elements(self, doc, condition, iterate=None):
         bad = []
@@ -476,8 +476,10 @@ class Cleaner(object):
             el.drop_tree()
 
     def _remove_javascript_link(self, link):
+        from urllib.parse import unquote
         # links like "j a v a s c r i p t:" might be interpreted in IE
-        new = _substitute_whitespace('', link)
+        # links like "javascrip%0at:alert()" will be interpreted
+        new = _substitute_whitespace('', unquote(link))
         if _is_javascript_scheme(new):
             # FIXME: should this be None to delete?
             return ''
@@ -640,7 +642,7 @@ def _link_text(text, link_regexes, avoid_hosts, factory):
         links.append(anchor)
         text = text[end:]
     return leading_text, links
-                
+
 def autolink_html(html, *args, **kw):
     result_type = type(html)
     if isinstance(html, basestring):
@@ -733,4 +735,4 @@ def _insert_break(word, width, break_character):
         word = word[len(start):]
     result += word
     return result
-    
+

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -68,6 +68,18 @@ class CleanerTest(unittest.TestCase):
         s = lxml.html.fromstring('<invalid tag>child</another>')
         self.assertEqual('child', clean_html(s).text_content())
 
+    def test_clean_javascript(self):
+        cleaner = Cleaner()
+        js = '<a href="javascrip%0at:alert(xxx)">test clean_html</a>'
+        self.assertEqual(
+            cleaner.clean_html(js), '<a href="">test clean_html</a>')
+        js = '<a href="j a v a s c r i p t:alert(xxx)">test clean_html</a>'
+        self.assertEqual(
+            cleaner.clean_html(js), '<a href="">test clean_html</a>')
+        # correct
+        js = '<a href="www.google.com">test clean_html</a>'
+        self.assertEqual(cleaner.clean_html(js), js)
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
links like `javascrip%0at:alert()` will cause a reflected XSS attack.

Thanks Omar Eissa from Deloitte Germany who found this issue.