### PR TITLE
Fix regression unknown error/undeclared vars while performing a xslt transform

### DIFF
--- a/src/lxml/xslt.pxi
+++ b/src/lxml/xslt.pxi
@@ -526,16 +526,8 @@ cdef class XSLT:
         # anyway.
         if transform_ctxt.dict is not NULL:
             xmlparser.xmlDictFree(transform_ctxt.dict)
-        if kw:
-            # parameter values are stored in the dict
-            # => avoid unnecessarily cluttering the global dict
-            transform_ctxt.dict = xmlparser.xmlDictCreateSub(self._c_style.doc.dict)
-            if transform_ctxt.dict is NULL:
-                xslt.xsltFreeTransformContext(transform_ctxt)
-                raise MemoryError()
-        else:
-            transform_ctxt.dict = self._c_style.doc.dict
-            xmlparser.xmlDictReference(transform_ctxt.dict)
+        transform_ctxt.dict = self._c_style.doc.dict
+        xmlparser.xmlDictReference(transform_ctxt.dict)
 
         xslt.xsltSetCtxtParseOptions(
             transform_ctxt, input_doc._parser._parse_options)


### PR DESCRIPTION
Regression came up while updating from lxml 2.2.8. In a complex environment parameters were
suddenly reported as not declared after the lxml update like:
<xslt>:100:0:ERROR:XSLT:ERR_OK: runtime error, element 'result'
<string>:0:0:ERROR:XSLT:ERR_OK: Variable 'name' has not been declared.
<string>:0:0:ERROR:XSLT:ERR_OK: unknown error

Running the same transformation with the same template and inputs outside the
complex environment does not reproduce the error. The "complex environment" did several
xml operations before across multiple threads which seem to be important to reproduce the
issue.

At the end the issue seem to be caused by the string "name" which is contained in two dicts
and therefore with different addresses. The xsltXPathVariableLookup function does only a pointer
comparison and so "name" was != "name".