### PR TITLE
doc: fix 2 links lxml-source-howto.txt

### DIFF
--- a/doc/lxml-source-howto.txt
+++ b/doc/lxml-source-howto.txt
@@ -154,7 +154,7 @@ lxml.etree
 ==========
 
 The main module, ``lxml.etree``, is in the file `lxml.etree.pyx
-<https://github.com/lxml/lxml/blob/master/src/lxml/lxml.etree.pyx>`_.  It
+<https://github.com/lxml/lxml/blob/master/src/lxml/etree.pyx>`_.  It
 implements the main functions and types of the ElementTree API, as
 well as all the factory functions for proxies.  It is the best place
 to start if you want to find out how a specific feature is
@@ -303,7 +303,7 @@ lxml.objectify
 A Cython implemented extension module that uses the public C-API of
 lxml.etree.  It provides a Python object-like interface to XML trees.
 The implementation resides in the file `lxml.objectify.pyx
-<https://github.com/lxml/lxml/blob/master/src/lxml/lxml.objectify.pyx>`_.
+<https://github.com/lxml/lxml/blob/master/src/lxml/objectify.pyx>`_.
 
 
 lxml.html


### PR DESCRIPTION
A drive-by fix for the 2 links from https://lxml.de/lxml-source-howto.html to appropriate sources on Github.