### PR TITLE
use " double quotes in pretty printed XML declaration

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -273,16 +273,16 @@ cdef void _writeDeclarationToBuffer(tree.xmlOutputBuffer* c_buffer,
                                     int standalone) nogil:
     if version is NULL:
         version = <unsigned char*>"1.0"
-    tree.xmlOutputBufferWrite(c_buffer, 15, "<?xml version='")
+    tree.xmlOutputBufferWrite(c_buffer, 15, '''<?xml version="''')
     tree.xmlOutputBufferWriteString(c_buffer, <const_char*>version)
-    tree.xmlOutputBufferWrite(c_buffer, 12, "' encoding='")
+    tree.xmlOutputBufferWrite(c_buffer, 12, '''" encoding="''')
     tree.xmlOutputBufferWriteString(c_buffer, encoding)
     if standalone == 0:
-        tree.xmlOutputBufferWrite(c_buffer, 20, "' standalone='no'?>\n")
+        tree.xmlOutputBufferWrite(c_buffer, 20, '''" standalone="no"?>\n''')
     elif standalone == 1:
-        tree.xmlOutputBufferWrite(c_buffer, 21, "' standalone='yes'?>\n")
+        tree.xmlOutputBufferWrite(c_buffer, 21, '''" standalone="yes"?>\n''')
     else:
-        tree.xmlOutputBufferWrite(c_buffer, 4, "'?>\n")
+        tree.xmlOutputBufferWrite(c_buffer, 4, '''"?>\n''')
 
 cdef void _writeDtdToBuffer(tree.xmlOutputBuffer* c_buffer,
                             xmlDoc* c_doc, const_xmlChar* c_root_name,


### PR DESCRIPTION
While both ' and " are valid in XML,  by convention, " double quotes are standard in the XML Declaration.  Indeed lxml already uses " double quotes in the `DOCTYPE` declaration.

* https://en.wikipedia.org/wiki/XHTML#XML_declaration
* https://xmlwriter.net/xml_guide/xml_declaration.shtml
* https://www.tutorialspoint.com/xml/xml_declaration.htm
* https://developer.mozilla.org/en-US/docs/XML_introduction
* https://msdn.microsoft.com/en-us/library/ms256048(v=vs.110).aspx
* https://stackoverflow.com/questions/6800467/quotes-in-xml-single-or-double

For some context of where this can be important, pretty printing should create as few diffs as possible:
https://github.com/WeblateOrg/weblate/issues/2333