### PR TITLE
Add a "keep_tail=True" option to Element.clear()

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -870,11 +870,13 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
             _assertValidNode(element)
             _appendChild(self, element)
 
-    def clear(self):
-        u"""clear(self)
+    def clear(self, bint keep_tail=False):
+        u"""clear(self, keep_tail=False)
 
         Resets an element.  This function removes all subelements, clears
         all attributes and sets the text and tail properties to None.
+
+        Pass ``keep_tail=True`` to leave the tail text untouched.
         """
         cdef xmlAttr* c_attr
         cdef xmlAttr* c_attr_next
@@ -884,7 +886,8 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
         c_node = self._c_node
         # remove self.text and self.tail
         _removeText(c_node.children)
-        _removeText(c_node.next)
+        if not keep_tail:
+            _removeText(c_node.next)
         # remove all attributes
         c_attr = c_node.properties
         while c_attr is not NULL:

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -241,6 +241,13 @@ class ETreeOnlyTestCase(HelperTestCase):
         self.assertRaises(ValueError,
                           etree.Element, "root", nsmap={'a:b' : 'testns'})
 
+    def test_clear_keep_tail(self):
+        XML = self.etree.XML
+        tostring = self.etree.tostring
+        a = XML('<a aa="A"><b ba="B">B1</b>B2<c ca="C">C1</c>C2</a>')
+        a[0].clear(keep_tail=True)
+        self.assertEqual(_bytes('<a aa="A"><b/>B2<c ca="C">C1</c>C2</a>'), tostring(a))
+
     def test_attribute_has_key(self):
         # ET in Py 3.x has no "attrib.has_key()" method
         XML = self.etree.XML


### PR DESCRIPTION
This helps with a common need in document-style XML/HTML.