### PR TITLE
Would it be possible to support Python on iOS?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os: linux
 dist: trusty
-sudo: false
 
 language: python
 
@@ -31,24 +30,19 @@ env:
 matrix:
   include:
     - python: 3.7
-      dist: xenial    # Required for Python 3.7
-      sudo: required  # travis-ci/travis-ci#9069
+      dist: xenial    # Required for Python >= 3.7
       env: STATIC_DEPS=false EXTRA_DEPS=coverage
     - python: 3.7
-      dist: xenial    # Required for Python 3.7
-      sudo: required  # travis-ci/travis-ci#9069
+      dist: xenial    # Required for Python >= 3.7
       env: STATIC_DEPS=false
     - python: 3.7
-      dist: xenial    # Required for Python 3.7
-      sudo: required  # travis-ci/travis-ci#9069
+      dist: xenial    # Required for Python >= 3.7
       env: STATIC_DEPS=true
     - python: 3.8-dev
-      dist: xenial    # Required for Python 3.7
-      sudo: required  # travis-ci/travis-ci#9069
+      dist: xenial    # Required for Python >= 3.7
       env: STATIC_DEPS=false
     - python: 3.8-dev
-      dist: xenial    # Required for Python 3.7
-      sudo: required  # travis-ci/travis-ci#9069
+      dist: xenial    # Required for Python >= 3.7
       env: STATIC_DEPS=true
     - python: 3.6
       env:


### PR DESCRIPTION
Both of the major implementations of Python 3 on iOS have long standing issues about supporting lxml. omz/Pythonista-Issues#245 and ColdGrub1384/Pyto#25  However, Apple rejects their attempts to add lxml support because the AppStore guidelines prohibit accessing private APIs.  Is there a way for lxml to support iOS as a first class platform in such a way that lxml could be added without violating the AppStore guidelines?


Unrelated to the iOS questions above...  This PR proposes removing the Travis CI __sudo:__ tag because it has become a no-op now that sudo is _always_ available on Travis CI.

__sudo: required__ no longer is...  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"