### PR TITLE
Fill python_requires with proper metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ if versioninfo.is_pre_release():
 extra_options = {}
 if 'setuptools' in sys.modules:
     extra_options['zip_safe'] = False
+    extra_options['python_requires'] = (
+        '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*')
 
     try:
         import pkg_resources

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,6 @@ an appropriate version of Cython installed.
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
Filling python_requires prevents pip from installing the package if it runs with an unsupported version.
See https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires