### PR TITLE
Fixed broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ fast Python XML processing.
             :height: 47
             :alt: Donate to the lxml project
 
-.. _`doc/main.txt`: http://lxml.de/
+.. _`doc/main.txt`: https://github.com/lxml/lxml/blob/master/doc/main.txt
 .. _`INSTALL.txt`: http://lxml.de/installation.html
 
 `Travis-CI <https://travis-ci.org/>`_ and `AppVeyor <https://www.appveyor.com/>`_


### PR DESCRIPTION
The link labeled "doc/main.txt" leads to "lxml.de", which redirects to "https://www.fridaysforfuture.org/". This mistake is misleading, so I corrected the link to point to the real "doc/main.txt".