### PR TITLE
Fix: false detection of recursive include

### DIFF
--- a/src/lxml/ElementInclude.py
+++ b/src/lxml/ElementInclude.py
@@ -207,8 +207,7 @@ def _include(elem, loader=None, base_url=None,
                     raise FatalIncludeError(
                         "cannot load %r as %r" % (href, parse)
                         )
-                _parent_hrefs_for_node = set([href]) | _parent_hrefs
-                node = _include(node, loader, href, max_depth - 1, _parent_hrefs_for_node)
+                node = _include(node, loader, href, max_depth - 1, {href} | _parent_hrefs)
                 if e.tail:
                     node.tail = (node.tail or "") + e.tail
                 if parent is None:

--- a/src/lxml/ElementInclude.py
+++ b/src/lxml/ElementInclude.py
@@ -202,13 +202,13 @@ def _include(elem, loader=None, base_url=None,
                 if max_depth == 0:
                     raise LimitedRecursiveIncludeError(
                         "maximum xinclude depth reached when including file %s" % href)
-                _parent_hrefs.add(href)
                 node = load_include(href, parse, parser=parser)
                 if node is None:
                     raise FatalIncludeError(
                         "cannot load %r as %r" % (href, parse)
                         )
-                node = _include(node, loader, href, max_depth - 1, _parent_hrefs)
+                _parent_hrefs_for_node = set([href]) | _parent_hrefs
+                node = _include(node, loader, href, max_depth - 1, _parent_hrefs_for_node)
                 if e.tail:
                     node.tail = (node.tail or "") + e.tail
                 if parent is None:

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -4344,19 +4344,28 @@ class ElementIncludeTestCase(_XIncludeTestCase):
     XINCLUDE["NonRecursive1.xml"] = """\
     <?xml version='1.0'?>
     <document xmlns:xi="http://www.w3.org/2001/XInclude">
-      <p>The following is multiple times the source code of NonRecursive2.xml:</p>
-      <xi:include href="NonRecursive2.xml"/>
-      <xi:include href="NonRecursive2.xml"/>
+      <p>The following is multiple times the source code of NonRecursive3.xml:</p>
+      <xi:include href="NonRecursive3.xml"/>
+      <xi:include href="NonRecursive3.xml"/>
       <p>The following is multiple times the source code of Leaf.xml:</p>
       <xi:include href="Leaf.xml"/>
       <xi:include href="Leaf.xml"/>
       <xi:include href="Leaf.xml"/>
-      <p>One more time the source code of NonRecursive2.xml:</p>
-      <xi:include href="NonRecursive2.xml"/>
+      <p>One more time the source code of NonRecursive3.xml:</p>
+      <xi:include href="NonRecursive3.xml"/>
     </document>
     """
 
     XINCLUDE["NonRecursive2.xml"] = """\
+    <?xml version='1.0'?>
+    <document xmlns:xi="http://www.w3.org/2001/XInclude">
+      <p>The following is multiple times the source code of NonRecursive3.xml:</p>
+      <xi:include href="NonRecursive3.xml"/>
+      <xi:include href="NonRecursive3.xml"/>
+    </document>
+    """
+
+    XINCLUDE["NonRecursive3.xml"] = """\
     <?xml version='1.0'?>
     <document xmlns:xi="http://www.w3.org/2001/XInclude">
       <p>The following is multiple times the source code of Leaf.xml:</p>
@@ -4423,11 +4432,15 @@ class ElementIncludeTestCase(_XIncludeTestCase):
     def test_multiple_include_of_same_file(self):
         # Test that including the same file multiple times, but on the same level
         # is not detected as recursive include
-        document = self.xinclude_loader("NonRecursive2.xml").getroottree()
+        document = self.xinclude_loader("NonRecursive3.xml").getroottree()
         self.include(document, self.xinclude_loader)
 
         # same but for more than one level
         document = self.xinclude_loader("NonRecursive1.xml").getroottree()
+        self.include(document, self.xinclude_loader)
+
+        # same but no Leaf.xml in top-level file
+        document = self.xinclude_loader("NonRecursive2.xml").getroottree()
         self.include(document, self.xinclude_loader)
 
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -4341,6 +4341,37 @@ class ElementIncludeTestCase(_XIncludeTestCase):
     </document>
     """
 
+    XINCLUDE["NonRecursive1.xml"] = """\
+    <?xml version='1.0'?>
+    <document xmlns:xi="http://www.w3.org/2001/XInclude">
+      <p>The following is multiple times the source code of NonRecursive2.xml:</p>
+      <xi:include href="NonRecursive2.xml"/>
+      <xi:include href="NonRecursive2.xml"/>
+      <p>The following is multiple times the source code of Leaf.xml:</p>
+      <xi:include href="Leaf.xml"/>
+      <xi:include href="Leaf.xml"/>
+      <xi:include href="Leaf.xml"/>
+      <p>One more time the source code of NonRecursive2.xml:</p>
+      <xi:include href="NonRecursive2.xml"/>
+    </document>
+    """
+
+    XINCLUDE["NonRecursive2.xml"] = """\
+    <?xml version='1.0'?>
+    <document xmlns:xi="http://www.w3.org/2001/XInclude">
+      <p>The following is multiple times the source code of Leaf.xml:</p>
+      <xi:include href="Leaf.xml"/>
+      <xi:include href="Leaf.xml"/>
+    </document>
+    """
+
+    XINCLUDE["Leaf.xml"] = """\
+    <?xml version='1.0'?>
+    <document xmlns:xi="http://www.w3.org/2001/XInclude">
+      <p>No further includes</p>
+    </document>
+    """
+
     def xinclude_loader(self, href, parse="xml", encoding=None):
         try:
             data = textwrap.dedent(self.XINCLUDE[href])
@@ -4388,6 +4419,16 @@ class ElementIncludeTestCase(_XIncludeTestCase):
             self.include(document, self.xinclude_loader, max_depth=3)
         self.assertEqual(str(cm.exception),
                          "recursive include of 'Recursive2.xml' detected")
+
+    def test_multiple_include_of_same_file(self):
+        # Test that including the same file multiple times, but on the same level
+        # is not detected as recursive include
+        document = self.xinclude_loader("NonRecursive2.xml").getroottree()
+        self.include(document, self.xinclude_loader)
+
+        # same but for more than one level
+        document = self.xinclude_loader("NonRecursive1.xml").getroottree()
+        self.include(document, self.xinclude_loader)
 
 
 class ETreeC14NTestCase(HelperTestCase):


### PR DESCRIPTION
In some cases ElementInclude does raise FatalIncludeError because of
recursive include detection. This is the case if the same file gets
included multiple times, but not recursive.

This is a fix for https://bugs.launchpad.net/lxml/+bug/1835708