### PR TITLE
Document Python 3.8 support in classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -232,6 +232,7 @@ an appropriate version of Cython installed.
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: C',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: HTML',


### PR DESCRIPTION
The module is now tested (in CI) and works fine Python 3.8, so document the support in classifiers.