### PR TITLE
make it easier to inspect element 

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -1121,7 +1121,10 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
     # ACCESSORS
     def __repr__(self):
         u"__repr__(self)"
-        return "<Element %s at 0x%x, %s>" % (strrepr(self.tag), id(self), self.attrib)
+        if self.text:
+            return "<Element %s at 0x%x, %s(%s)>" % (strrepr(self.tag), id(self), self.attrib, self.text)
+        else:
+            return "<Element %s at 0x%x, %s>" % (strrepr(self.tag), id(self), self.attrib)
 
     def __getitem__(self, x):
         u"""Returns the subelement at the given position or the requested

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -1121,7 +1121,7 @@ cdef public class _Element [ type LxmlElementType, object LxmlElement ]:
     # ACCESSORS
     def __repr__(self):
         u"__repr__(self)"
-        return "<Element %s at 0x%x>" % (strrepr(self.tag), id(self))
+        return "<Element %s at 0x%x, %s>" % (strrepr(self.tag), id(self), self.attrib)
 
     def __getitem__(self, x):
         u"""Returns the subelement at the given position or the requested


### PR DESCRIPTION
repr will show more information.
For example, for tag a, it will display something like this:
```
<Element a at 0x103c20820, {'href': '#', 'onclick': "javascript:windowHandle = window.open('http://example.com','popup', 'toolbar=0,scrollbars=1,location=0,statusbar=0,menubar=0,resizable=1,width=1020,height=600,left = 1,top = 1');windowHandle.focus();"}>
```
instead of
```
<Element a at 0x103c20820>.
```
The latter is not very useful.