### PR TITLE
Make iter() work with qnames

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -2741,6 +2741,8 @@ cdef class _MultiTagMatcher:
                 elif href == b'*':
                     href = None  # wildcard: any namespace, including none
                 self._py_tags.append((href, name))
+        elif isinstance(tag, QName):
+            self._storeTags(tag.text, seen)
         else:
             # support a sequence of tags
             for item in tag:

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3289,6 +3289,30 @@ class ETreeOnlyTestCase(HelperTestCase):
         self.assertEqual(len(list(tree.findall(QName("b")))), 2)
         self.assertEqual(len(list(tree.findall(QName("X", "b")))), 1)
 
+    def test_elementtree_iter_qname(self):
+        XML = self.etree.XML
+        ElementTree = self.etree.ElementTree
+        QName = self.etree.QName
+        tree = ElementTree(XML(
+                _bytes('<a xmlns:x="X" xmlns:y="Y"><x:b><c/></x:b><b/><c><x:b/><b/></c><b/></a>')))
+        self.assertEqual(
+            list(tree.iter(QName("b"))),
+            list(tree.iter("b")),
+        )
+        self.assertEqual(
+            list(tree.iter(QName("X", "b"))),
+            list(tree.iter("{X}b")),
+        )
+
+        self.assertEqual(
+            [e.tag for e in tree.iter(QName("X", "b"), QName("b"))],
+            ['{X}b', 'b', '{X}b', 'b', 'b']
+        )
+        self.assertEqual(
+            list(tree.iter(QName("X", "b"), QName("b"))),
+            list(tree.iter("{X}b", "b"))
+        )
+
     def test_findall_ns(self):
         XML = self.etree.XML
         root = XML(_bytes('<a xmlns:x="X" xmlns:y="Y"><x:b><c/></x:b><b/><c><x:b/><b/></c><b/></a>'))

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -3266,29 +3266,6 @@ class ETreeOnlyTestCase(HelperTestCase):
         self.assertRaises(ValueError, tree.getelementpath, d1)
         self.assertRaises(ValueError, tree.getelementpath, d2)
 
-    def test_elementtree_find_qname(self):
-        XML = self.etree.XML
-        ElementTree = self.etree.ElementTree
-        QName = self.etree.QName
-        tree = ElementTree(XML(_bytes('<a><b><c/></b><b/><c><b/></c></a>')))
-        self.assertEqual(tree.find(QName("c")), tree.getroot()[2])
-
-    def test_elementtree_findall_qname(self):
-        XML = self.etree.XML
-        ElementTree = self.etree.ElementTree
-        QName = self.etree.QName
-        tree = ElementTree(XML(_bytes('<a><b><c/></b><b/><c><b/></c></a>')))
-        self.assertEqual(len(list(tree.findall(QName("c")))), 1)
-
-    def test_elementtree_findall_ns_qname(self):
-        XML = self.etree.XML
-        ElementTree = self.etree.ElementTree
-        QName = self.etree.QName
-        tree = ElementTree(XML(
-                _bytes('<a xmlns:x="X" xmlns:y="Y"><x:b><c/></x:b><b/><c><x:b/><b/></c><b/></a>')))
-        self.assertEqual(len(list(tree.findall(QName("b")))), 2)
-        self.assertEqual(len(list(tree.findall(QName("X", "b")))), 1)
-
     def test_elementtree_iter_qname(self):
         XML = self.etree.XML
         ElementTree = self.etree.ElementTree
@@ -3312,6 +3289,29 @@ class ETreeOnlyTestCase(HelperTestCase):
             list(tree.iter(QName("X", "b"), QName("b"))),
             list(tree.iter("{X}b", "b"))
         )
+
+    def test_elementtree_find_qname(self):
+        XML = self.etree.XML
+        ElementTree = self.etree.ElementTree
+        QName = self.etree.QName
+        tree = ElementTree(XML(_bytes('<a><b><c/></b><b/><c><b/></c></a>')))
+        self.assertEqual(tree.find(QName("c")), tree.getroot()[2])
+
+    def test_elementtree_findall_qname(self):
+        XML = self.etree.XML
+        ElementTree = self.etree.ElementTree
+        QName = self.etree.QName
+        tree = ElementTree(XML(_bytes('<a><b><c/></b><b/><c><b/></c></a>')))
+        self.assertEqual(len(list(tree.findall(QName("c")))), 1)
+
+    def test_elementtree_findall_ns_qname(self):
+        XML = self.etree.XML
+        ElementTree = self.etree.ElementTree
+        QName = self.etree.QName
+        tree = ElementTree(XML(
+                _bytes('<a xmlns:x="X" xmlns:y="Y"><x:b><c/></x:b><b/><c><x:b/><b/></c><b/></a>')))
+        self.assertEqual(len(list(tree.findall(QName("b")))), 2)
+        self.assertEqual(len(list(tree.findall(QName("X", "b")))), 1)
 
     def test_findall_ns(self):
         XML = self.etree.XML


### PR DESCRIPTION
"QName" is supposed to be usable anywhere a tag name is expected and iter() should take any number of tag names for filtering, but before this change passing a QName to iter() results in an exception.

Fixes https://bugs.launchpad.net/lxml/+bug/1865141