### PR TITLE
Update tox to match travis and appveyor matrices (remove py34, add py38)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37
+envlist = py27, py35, py36, py37, py38
 
 [testenv]
 setenv =


### PR DESCRIPTION
While running tests for #298 I realised Py38 was not in the toxfile, but tests pass under 3.8 and indeed on the PR both appveyor and travis run 3.8.

This PR updates the toxfile to add Python 3.8, matching 9bab0e1fef7bffcdcdb1ee0080718633dea7ada5

While at it, drop 3.4 from the toxfile as it was dropped from appveyor in 7adcdc0e6de170b423b32985577f40f20a3b2f08 and travis in b055581bf4492de6da7678fbe7404b0232da6d84