### PR TITLE
Cleaner: Catch bad arg combo in constructor

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -223,10 +223,10 @@ class Cleaner(object):
         if self.inline_style is None and 'inline_style' not in kw:
             self.inline_style = self.style
 
-        assert not all([kw.get("allow_tags"), kw.get("remove_unknown_tags")]), \
-            "It does not make sense to pass in both allow_tags and remove_unknown_tags"
-
         if kw.get("allow_tags"):
+            if kw.get("remove_unknown_tags"):
+                raise ValueError("It does not make sense to pass in both "
+                                 "allow_tags and remove_unknown_tags")
             self.remove_unknown_tags = False
 
     # Used to lookup the primary URL for a given tag that is up for

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -207,7 +207,7 @@ class Cleaner(object):
     remove_tags = None
     allow_tags = None
     kill_tags = None
-    remove_unknown_tags = True
+    remove_unknown_tags = None
     safe_attrs_only = True
     safe_attrs = defs.safe_attrs
     add_nofollow = False
@@ -222,6 +222,14 @@ class Cleaner(object):
             setattr(self, name, value)
         if self.inline_style is None and 'inline_style' not in kw:
             self.inline_style = self.style
+
+        assert not all([kw.get("allow_tags"), kw.get("remove_unknown_tags")]), \
+            "It does not make sense to pass in both allow_tags and remove_unknown_tags"
+
+        if kw.get("allow_tags"):
+            setattr(self, "remove_unknown_tags", False)
+        else:
+            setattr(self, "remove_unknown_tags", True)
 
     # Used to lookup the primary URL for a given tag that is up for
     # removal:

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -227,9 +227,7 @@ class Cleaner(object):
             "It does not make sense to pass in both allow_tags and remove_unknown_tags"
 
         if kw.get("allow_tags"):
-            setattr(self, "remove_unknown_tags", False)
-        else:
-            setattr(self, "remove_unknown_tags", True)
+            self.remove_unknown_tags = False
 
     # Used to lookup the primary URL for a given tag that is up for
     # removal:

--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -207,7 +207,7 @@ class Cleaner(object):
     remove_tags = None
     allow_tags = None
     kill_tags = None
-    remove_unknown_tags = None
+    remove_unknown_tags = True
     safe_attrs_only = True
     safe_attrs = defs.safe_attrs
     add_nofollow = False

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -34,6 +34,21 @@ class CleanerTest(unittest.TestCase):
 
         self.assertEqual(12-5+1, len(list(result.iter())))
 
+    def test_allow_and_remove(self):
+        with self.assertRaises(AssertionError):
+            Cleaner(allow_tags=['a'], remove_unknown_tags=True)
+
+    def test_remove_unknown_tags(self):
+        html = """<div><bun>lettuce, tomato, veggie patty</bun></div>"""
+        clean_html = """<div>lettuce, tomato, veggie patty</div>"""
+        cleaner = Cleaner(remove_unknown_tags=True)
+        result = cleaner.clean_html(html)
+        self.assertEqual(
+            result,
+            clean_html,
+            msg="Unknown tags not removed. Got: %s" % result,
+        )
+
     def test_safe_attrs_included(self):
         html = """<p><span style="color: #00ffff;">Cyan</span></p>"""
 

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -35,7 +35,7 @@ class CleanerTest(unittest.TestCase):
         self.assertEqual(12-5+1, len(list(result.iter())))
 
     def test_allow_and_remove(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             Cleaner(allow_tags=['a'], remove_unknown_tags=True)
 
     def test_remove_unknown_tags(self):


### PR DESCRIPTION
This ensures that if people provide both allow_tags and remove_unknown_tags when constructing the cleaner, it'll fail. I left the old check in the `clean_html` method in case somebody did something weird like:

```
c = Cleaner()
c.allow_tags = [a]
c.remove_unknown_tags = True
```

I was able to get lxml to build and was able to run the tests, which pass.

I was unable to figure out how to run just a single test though, which would have been nice. Perhaps it's in the instructions, but I didn't see it here:

https://lxml.de/build.html

As somebody that's never used Cython before, I was also pretty confused about when I had to rebuild things, but I eventually figured out that when I change the code: rebuild. When changing tests: don't. 