### PR TITLE
Add ppc64le jobs to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,12 @@ matrix:
     - python: 3.8
       env: STATIC_DEPS=true
       arch: arm64
+    - python: 3.8
+      env: STATIC_DEPS=false
+      arch: ppc64le
+    - python: 3.8
+      env: STATIC_DEPS=true
+      arch: ppc64le
   allow_failures:
     - python: pypy
     - python: pypy3


### PR DESCRIPTION
As with ARM64, Travis CI supports ppc64le ("Power") now. It would be nice to test on that platform too.

I've just mimicked the jobs that ARM64 does: I think that provides decent coverage without bloating the test matrix too much. (We could also test pypy on Power, but I don't think it gets us too much extra value.)

If any issues come up with the Power build in future, feel free to tag me in and I'll have a look - I have access to Power systems at work.
