### PR TITLE
Makefile: fix double quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ CYTHON3_WITH_COVERAGE:=$(shell $(PYTHON3) -c 'import Cython.Coverage; import sys
 
 MANYLINUX_LIBXML2_VERSION=2.9.10
 MANYLINUX_LIBXSLT_VERSION=1.1.34
-MANYLINUX_CFLAGS="-O3 -g1 -pipe -fPIC -flto"
-MANYLINUX_LDFLAGS="-flto"
+MANYLINUX_CFLAGS=-O3 -g1 -pipe -fPIC -flto
+MANYLINUX_LDFLAGS=-flto
 MANYLINUX_IMAGE_X86_64=quay.io/pypa/manylinux1_x86_64
 MANYLINUX_IMAGE_686=quay.io/pypa/manylinux1_i686
 MANYLINUX_IMAGE_AARCH64=quay.io/pypa/manylinux2014_aarch64


### PR DESCRIPTION
With the current Makefile running `make wheel_manylinux` produces the following output

```
time docker run --rm -t \
        -v /home/user/Works/maieuticallabs/lxml:/io \
         \
        -e CFLAGS=""-O3 -g1 -pipe -fPIC -flto" -march=core2" \
        -e LDFLAGS=""-flto"" \
        -e LIBXML2_VERSION="2.9.10" \
        -e LIBXSLT_VERSION="1.1.34" \
        -e WHEELHOUSE=wheelhouse_manylinux64 \
        quay.io/pypa/manylinux1_x86_64 \
        bash /io/tools/manylinux/build-wheels.sh /io/dist/lxml-4.5.2.tar.gz
unknown shorthand flag: 'g' in -g1
See 'docker run --help'.
```
this PR removes double quotes from variables declaration fixing the issue
