### PR TITLE
adds initial fuzzer for oss-fuzz integration.

### DIFF
--- a/src/lxml/tests/fuzz_xml_parse.py
+++ b/src/lxml/tests/fuzz_xml_parse.py
@@ -1,0 +1,26 @@
+
+"""
+
+Fuzzes the lxml.etree.XML function with the Atheris fuzzer.
+
+The goal is to catch unhandled exceptions and potential 
+memory corruption issues in auto-generated code.
+
+"""
+
+import atheris
+import sys
+
+from lxml import etree as et
+
+def TestOneInput(data):
+  fdp = atheris.FuzzedDataProvider(data)
+
+  try:
+    root = et.XML(fdp.ConsumeUnicode(sys.maxsize))
+  except et.XMLSyntaxError:
+    None
+  return
+
+atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+atheris.Fuzz()

--- a/src/lxml/tests/fuzz_xml_parse.py
+++ b/src/lxml/tests/fuzz_xml_parse.py
@@ -18,5 +18,6 @@ def test_etree_xml(data):
     pass
   return
 
-atheris.Setup(sys.argv, test_etree_xml, enable_python_coverage=True)
-atheris.Fuzz()
+if __name__ == "__main__":
+    atheris.Setup(sys.argv, test_etree_xml, enable_python_coverage=True)
+    atheris.Fuzz()

--- a/src/lxml/tests/fuzz_xml_parse.py
+++ b/src/lxml/tests/fuzz_xml_parse.py
@@ -1,26 +1,22 @@
-
 """
-
 Fuzzes the lxml.etree.XML function with the Atheris fuzzer.
 
 The goal is to catch unhandled exceptions and potential 
 memory corruption issues in auto-generated code.
-
 """
 
 import atheris
 import sys
 
-from lxml import etree as et
+from lxml import etree
 
-def TestOneInput(data):
+def test_etree_xml(data):
   fdp = atheris.FuzzedDataProvider(data)
-
   try:
-    root = et.XML(fdp.ConsumeUnicode(sys.maxsize))
-  except et.XMLSyntaxError:
-    None
+    root = etree.XML(fdp.ConsumeUnicode(sys.maxsize))
+  except etree.XMLSyntaxError:
+    pass
   return
 
-atheris.Setup(sys.argv, TestOneInput, enable_python_coverage=True)
+atheris.Setup(sys.argv, test_etree_xml, enable_python_coverage=True)
 atheris.Fuzz()

--- a/src/lxml/tests/fuzz_xml_parse.py
+++ b/src/lxml/tests/fuzz_xml_parse.py
@@ -11,12 +11,12 @@ import sys
 from lxml import etree
 
 def test_etree_xml(data):
-  fdp = atheris.FuzzedDataProvider(data)
-  try:
-    root = etree.XML(fdp.ConsumeUnicode(sys.maxsize))
-  except etree.XMLSyntaxError:
-    pass
-  return
+    fdp = atheris.FuzzedDataProvider(data)
+    try:
+        root = etree.XML(fdp.ConsumeUnicode(sys.maxsize))
+    except etree.XMLSyntaxError:
+        pass
+    return
 
 if __name__ == "__main__":
     atheris.Setup(sys.argv, test_etree_xml, enable_python_coverage=True)


### PR DESCRIPTION
Hi,

Given the popularity of lxml I was thinking that it would be nice to set up continuous fuzzing of lxml, by way of OSS-Fuzz. In this PR: https://github.com/google/oss-fuzz/pull/4908 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate lxml. This includes developing initial fuzzers as well as integrating into OSS-Fuzz, however, it is preferable to have the fuzzers upstream so I included it in this PR - if you are happy with having the fuzzers here then I will remove them from the OSS-Fuzz repository.

Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects. Python support was recently provided and it can also fuzz native extensions, i.e. for memory corruption errors. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

If you would like to integrate, the only thing I need is as list of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. Notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.