### PR TITLE
Make it possible to control STATIC_* setup variables from the environ…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ import setupinfo
 def static_env_list(name, separator=None):
     return [x.strip() for x in os.environ.get(name, "").split(separator) if x.strip()]
 
-STATIC_INCLUDE_DIRS = static_env_list("LXML_STATIC_INCLUDE_DIRS", os.pathsep)
-STATIC_LIBRARY_DIRS = static_env_list("LXML_STATIC_LIBRARY_DIRS", os.pathsep)
+STATIC_INCLUDE_DIRS = static_env_list("LXML_STATIC_INCLUDE_DIRS", separator=os.pathsep)
+STATIC_LIBRARY_DIRS = static_env_list("LXML_STATIC_LIBRARY_DIRS", separator=os.pathsep)
 STATIC_CFLAGS = static_env_list("LXML_STATIC_CFLAGS")
-STATIC_BINARIES = static_env_list("LXML_STATIC_BINARIES", os.pathsep)
+STATIC_BINARIES = static_env_list("LXML_STATIC_BINARIES", separator=os.pathsep)
 
 # create lxml-version.h file
 versioninfo.create_version_h()

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,13 @@ import setupinfo
 # override these and pass --static for a static build. See
 # doc/build.txt for more information. If you do not pass --static
 # changing this will have no effect.
-STATIC_INCLUDE_DIRS = []
-STATIC_LIBRARY_DIRS = []
-STATIC_CFLAGS = []
-STATIC_BINARIES = []
+def static_env_list(name, separator=None):
+    return [x.strip() for x in os.environ.get(name, "").split(separator) if x.strip()]
+
+STATIC_INCLUDE_DIRS = static_env_list("LXML_STATIC_INCLUDE_DIRS", os.pathsep)
+STATIC_LIBRARY_DIRS = static_env_list("LXML_STATIC_LIBRARY_DIRS", os.pathsep)
+STATIC_CFLAGS = static_env_list("LXML_STATIC_CFLAGS")
+STATIC_BINARIES = static_env_list("LXML_STATIC_BINARIES", os.pathsep)
 
 # create lxml-version.h file
 versioninfo.create_version_h()


### PR DESCRIPTION
When trying to build lxml with a statically linked libxml, the `setup.py` file needs to be edited or else successfully building lxml is impossible.

This PR tries to provide a way to give more control over the static build settings from environment variables.

For example, assume that libxml and libxslt have been statically built and installed under `/my/salsa` and we want to build lxml so that libxml and libxslt are **embedded** into the extension modules.  With the suggested changes to the `setup.py` file applied, it should be possible to do it with a single `pip` command:

```
STATIC=true \
LXML_STATIC_INCLUDE_DIRS="/my/salsa/include/libxml2" \
LXML_STATIC_LIBRARY_DIRS="/my/salsa/lib" \
LXML_STATIC_BINARIES="/my/salsa/lib/libxslt.a:/my/salsa/lib/libexslt.a:/my/salsa/lib/libxml2.a" \
WITH_XML2_CONFIG="/my/salsa/bin/xml2-config" \
WITH_XSLT_CONFIG="/my/salsa/bin/xslt-config" \
      pip install --no-binary=:all: lxml
```
