### PR TITLE
Python 3.10 alpha 5: undefined symbol: _PyGen_Send

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,5 +81,5 @@ script:
   - ccache -s || true
   - CFLAGS="-O0 -g -fPIC" PYTHONUNBUFFERED=x make test
   - ccache -s || true
-  - python -m pip install lxml
+  - python setup.py install
   - python -c "from lxml import etree"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,5 @@ script:
   - ccache -s || true
   - CFLAGS="-O0 -g -fPIC" PYTHONUNBUFFERED=x make test
   - ccache -s || true
+  - python -m pip install lxml
   - python -c "from lxml import etree"

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,3 +81,4 @@ script:
   - ccache -s || true
   - CFLAGS="-O0 -g -fPIC" PYTHONUNBUFFERED=x make test
   - ccache -s || true
+  - python -c "from lxml import etree"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
     - libs
 
 python:
+  - nightly
   - 3.9
   - 2.7
   - 3.8
@@ -61,6 +62,7 @@ matrix:
       env: STATIC_DEPS=true
       arch: ppc64le
   allow_failures:
+    - python: nightly
     - python: pypy
     - python: pypy3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - libs
 
 python:
-  - nightly
+  - nightly 
   - 3.9
   - 2.7
   - 3.8


### PR DESCRIPTION
`from lxml import etree`  # on Python 3.10 alpha 5 --> https://travis-ci.org/github/lxml/lxml/jobs/759988867#L421-L424

E   ImportError: /opt/hostedtoolcache/Python/3.10.0-alpha.5/x64/lib/python3.10/site-packages/lxml/etree.cpython-310-x86_64-linux-gnu.so: undefined symbol: _PyGen_Send

@scoder