### PR TITLE
enabling access to per-entity system_url

### DIFF
--- a/src/lxml/dtd.pxi
+++ b/src/lxml/dtd.pxi
@@ -258,6 +258,11 @@ cdef class _DTDEntityDecl:
         _assertValidDTDNode(self, self._c_node)
         return funicodeOrNone(self._c_node.content)
 
+    @property
+    def system_url(self):
+        _assertValidDTDNode(self, self._c_node)
+        return funicodeOrNone(self._c_node.SystemID)
+
 
 ################################################################################
 # DTD

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -407,6 +407,10 @@ class ETreeDtdTestCase(HelperTestCase):
         xml = etree.parse(BytesIO('<!DOCTYPE test [ <!ENTITY TestReference SYSTEM "./foo.bar"> ]><a/>'))
         self.assertEqual(xml.docinfo.internalDTD.entities()[0].system_url, "./foo.bar")
 
+    def test_entity_system_url_none(self):
+        xml = etree.parse(BytesIO('<!DOCTYPE test [ <!ENTITY TestReference "testvalue"> ]><a/>'))
+        self.assertEqual(xml.docinfo.internalDTD.entities()[0].system_url, None)
+
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -403,6 +403,10 @@ class ETreeDtdTestCase(HelperTestCase):
         self.assertEqual(etree.tostring(doc),
                          _bytes(data))
 
+    def test_entity_system_url(self):
+        xml = etree.parse(BytesIO('<!DOCTYPE test [ <!ENTITY TestReference SYSTEM "./foo.bar"> ]><a/>'))
+        self.assertEqual(xml.docinfo.internalDTD.entities()[0].system_url, "./foo.bar")
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
Same idea as the other @properties on this type, I would like access to the system url for ENTITY ... SYSTEM ... 
