### PR TITLE
Fix banner layout

### DIFF
--- a/doc/html/style.css
+++ b/doc/html/style.css
@@ -164,7 +164,7 @@ div.banner {
     border: 2px solid darkred;
     color: darkgreen;
     line-height: 1em;
-    margin: 1ex;
+    margin: 3ex 1ex 1ex;
     padding: 3pt;
 }
 


### PR DESCRIPTION
Tweak the CSS layout to avoid having the banner overlap with the tag line at some resolutions on the project page. See https://bugs.launchpad.net/lxml/+bug/1928553 (esp. attached screen shot). There may be more subtle tweaks which would make breakpoint-specific adjustments, but I went for this simpler modification, which seems to produce acceptable results at all resolutions.