### PR TITLE
add link to Github for PyPi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 .tox
 .idea
+.vscode
 build
 dist
 wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,9 @@ setup(
     # `Unknown distribution option: 'bugtrack_url'`
     # which distract folks from real causes of problems when troubleshooting
     # bugtrack_url="https://bugs.launchpad.net/lxml",
-
+    project_urls={
+        "Source": "https://github.com/lxml/lxml",
+    },
     description=(
         "Powerful and Pythonic XML processing library"
         " combining libxml2/libxslt with the ElementTree API."


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar, as well as including them in API responses to help automation tool find the source code for Pillow. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).