### PR TITLE
_tofilelikeC14N: Always close output buffer

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -862,15 +862,17 @@ cdef _tofilelikeC14N(f, _Element element, bint exclusive, bint with_comments,
         elif hasattr(f, 'write'):
             writer   = _FilelikeWriter(f, compression=compression)
             c_buffer = writer._createOutputBuffer(NULL)
-            with writer.error_log:
-                bytes_count = c14n.xmlC14NDocSaveTo(
-                    c_doc, NULL, exclusive, c_inclusive_ns_prefixes,
-                    with_comments, c_buffer)
+            try:
+                with writer.error_log:
+                    bytes_count = c14n.xmlC14NDocSaveTo(
+                        c_doc, NULL, exclusive, c_inclusive_ns_prefixes,
+                        with_comments, c_buffer)
+            finally:
                 error = tree.xmlOutputBufferClose(c_buffer)
-                if bytes_count < 0:
-                    error = bytes_count
-                elif error != -1:
-                    error = xmlerror.XML_ERR_OK
+            if bytes_count < 0:
+                error = bytes_count
+            elif error != -1:
+                error = xmlerror.XML_ERR_OK
         else:
             raise TypeError(f"File or filename expected, got '{python._fqtypename(f).decode('UTF-8')}'")
     finally:


### PR DESCRIPTION
Hello!
I'm reviewing output from a static analyzer, and found a piece of code that looks OK on closer inspection, but could be made more *obviously* correct.
I'm not very familiar with the code, but:

If `writer.error_log.__enter__` or `c14n.xmlC14NDocSaveTo` would
raise an exception, `c_buffer` would leak.
It seems that currently, neither of those can actually raise
(they're small tight `cdef` functions), but there's no
guarantee they'll remain exception-free in the future.

But there's one more thing that potentially could leak (at
least Cython generates an `unlikely` `goto` block for it):
the lookup of `__exit__` that happens at the start of the
`with` block.

---
There might be more like this as I trawl through static analyzer warnings and filter out false positives; are PRs like this helpful?