### PR TITLE
Include `libiconv` headers in the static wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ extra_options['packages'] = [
 
 
 def setup_extra_options():
-    is_interesting_package = re.compile('^(libxml|libxslt|libexslt)$').match
+    is_interesting_package = re.compile('^(libxml|libxslt|libexslt|libiconv)$').match
     def extract_files(directories, pattern='*'):
         def get_files(root, dir_path, files):
             return [ (root, dir_path, filename)


### PR DESCRIPTION
Since lxml's C-API could not be compiled without `libiconv`, include it in the static wheels. 

Fixes https://bugs.launchpad.net/lxml/+bug/1939031