### PR TITLE
Add a manylinux 'musllinux' variant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ MANYLINUX_IMAGES= \
 	manylinux_2_24_i686 \
 	manylinux_2_24_aarch64 \
 	manylinux_2_24_ppc64le \
-	manylinux_2_24_s390x
+	manylinux_2_24_s390x \
+	musllinux_1_1_x86_64
 
 AARCH64_ENV=-e AR="/opt/rh/devtoolset-9/root/usr/bin/gcc-ar" \
 		-e NM="/opt/rh/devtoolset-9/root/usr/bin/gcc-nm" \


### PR DESCRIPTION
This is useful for alpine linux containers, to avoid needing a
multistage build to build + install the lxml package.

I tested it by building using make, then installing and using the
package in an alpine linux container:

```bash
❯ make wheel_musllinux_1_1_x86_64

❯ docker run \
  --rm \
  --workdir /tmp/workdir \
  --volume="$PWD:/tmp/workdir" \
  -t alpine \
  sh -c "
  set -e
  apk add python3
  # virtualenv
  python3 -m venv ~/.venv
  . ~/.venv/bin/activate
  # need a more recent version of pip for manylinux wheels
  pip install pip==21.2.4
  pip install wheelhouse/musllinux_1_1_x86_64/lxml-4.6.3-cp39-cp39-musllinux_1_1_x86_64.whl
  python -c 'import lxml; print(lxml.__version__)'
  "