### PR TITLE
add win-arm64 support

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -38,14 +38,14 @@ def download_and_extract_windows_binaries(destdir):
         if release_path in filename
     ]
 
-    if platform.machine() == 'ARM64':
+    if sys.version_info < (3, 5):
+        arch = 'vs2008.' + arch
+    elif platform.machine() == 'ARM64':
         arch = "win-arm64"
     elif sys.maxsize > 2**32:
         arch = "win64"
     else:
         arch = "win32"
-    if sys.version_info < (3, 5):
-        arch = 'vs2008.' + arch
 
     libs = {}
     for libname in ['libxml2', 'libxslt', 'zlib', 'iconv']:


### PR DESCRIPTION
This patch enables building lxml package for win/arm64 platforms.

The change expects win/arm64 libraries to be available in [repository](https://github.com/mhils/libxml2-win-binaries) currently used for getting x86 and x64 dependencies. The packages are not yet available in the repository but a [PR](https://github.com/mhils/libxml2-win-binaries/pull/2) has been raised to add arm64 libraries.

Unofficial release of win/arm64 libraries from [PR](https://github.com/mhils/libxml2-win-binaries/pull/2) are available [here](https://github.com/nsait-linaro/libxml2-win-binaries/releases/tag/2021.10.36)

### Test Result

```

TESTED VERSION: 4.6.3
    Python:           sys.version_info(major=3, minor=10, micro=0, releaselevel='candidate', serial=1)
    lxml.etree:       (4, 6, 3, 0)
    libxml used:      (2, 9, 5)
    libxml compiled:  (2, 9, 5)
    libxslt used:     (1, 1, 30)
    libxslt compiled: (1, 1, 30)
    FS encoding:      utf-8
    Default encoding: utf-8
    Max Unicode:      1114111

----------------------------------------------------------------------
Ran 1937 tests in 7.474s

OK
```