### PR TITLE
Fix arch variable reference error in buildlibxml.py for older python versions

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -38,14 +38,15 @@ def download_and_extract_windows_binaries(destdir):
         if release_path in filename
     ]
 
-    if sys.version_info < (3, 5):
-        arch = 'vs2008.' + arch
-    elif platform.machine() == 'ARM64':
+    if platform.machine() == 'ARM64':
         arch = "win-arm64"
     elif sys.maxsize > 2**32:
         arch = "win64"
     else:
         arch = "win32"
+
+    if sys.version_info < (3, 5):
+        arch = 'vs2008.' + arch
 
     libs = {}
     for libname in ['libxml2', 'libxslt', 'zlib', 'iconv']:


### PR DESCRIPTION
See CI errors here

https://ci.appveyor.com/project/scoder/lxml/builds/41249423/job/vnu6gmaa3u0f4by7#L49
https://ci.appveyor.com/project/scoder/lxml/builds/41249423/job/173d08dq3bbx6mef#L57

