### PR TITLE
setupinfo.py: check the return value

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -365,7 +365,7 @@ def run_command(cmd, *args):
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout_data, errors = p.communicate()
 
-    if errors:
+    if p.returncode != 0 and errors:
         return ''
     return decode_input(stdout_data).strip()
 


### PR DESCRIPTION
```
Use the return value altogether to check the subprocess execute
successfully or not as in some case it will print some noise
message though run successfully as below.

 # python
 Python 3.8.10 (default, Nov 26 2021, 20:14:08)
 [GCC 9.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import subprocess
 >>> cmd = "pkg-config --modversion libxml-2.0"
 >>> p = subprocess.Popen(cmd, shell=True,stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 >>> stdout_data, errors = p.communicate()
 >>> print(stdout_data)
 b'2.9.12\n'
 >>> print(errors)
 b'do_ypcall: clnt_call: RPC: Unable to send; errno = Network is unreachable\n'
 >>>

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>
```