### PR TITLE
Add warning about the global `set_element_class_lookup`

### DIFF
--- a/doc/api/conf.py
+++ b/doc/api/conf.py
@@ -46,6 +46,7 @@ html_theme_options = {
 autodoc_default_options = {
     'ignore-module-all': True,
     'private-members': True,
+    'inherited-members': True,
 }
 
 autodoc_member_order = 'groupwise'

--- a/src/lxml/classlookup.pxi
+++ b/src/lxml/classlookup.pxi
@@ -549,7 +549,11 @@ cdef void _setElementClassLookupFunction(
 def set_element_class_lookup(ElementClassLookup lookup = None):
     u"""set_element_class_lookup(lookup = None)
 
-    Set the global default element class lookup method.
+    Set the global element class lookup method.
+
+    This defines the main entry point for looking up element implementations.
+    The standard implementation uses the :class:`ParserBasedElementClassLookup`
+    to delegate to different lookup schemes for each parser. 
 
     .. warning::
 

--- a/src/lxml/classlookup.pxi
+++ b/src/lxml/classlookup.pxi
@@ -553,13 +553,16 @@ def set_element_class_lookup(ElementClassLookup lookup = None):
 
     .. warning::
 
-        Setting the default element class to something other than a
-        :class:`ParserBasedElementClassLookup` will prevent
-        :meth:`~lxml.etree.XMLParser.set_element_class_lookup` from working.
+        This should only be changed by applications, not by library packages.
+        In most cases, parser specific lookups should be preferred,
+        which can be configured via
+        :meth:`~lxml.etree.XMLParser.set_element_class_lookup`
+        (and the same for HTML parsers).
 
-        Amongst other issues, this will break :mod:`lxml.html` and
-        :mod:`lxml.objectify`'s extensions as they rely on lookups configured
-        on their respective parsers.
+        Globally replacing the element class lookup by something other than a
+        :class:`ParserBasedElementClassLookup` will prevent parser specific lookup
+        schemes from working. Several tools rely on parser specific lookups,
+        including :mod:`lxml.html` and :mod:`lxml.objectify`.
     """
     if lookup is None or lookup._lookup_function is NULL:
         _setElementClassLookupFunction(NULL, None)

--- a/src/lxml/classlookup.pxi
+++ b/src/lxml/classlookup.pxi
@@ -550,6 +550,16 @@ def set_element_class_lookup(ElementClassLookup lookup = None):
     u"""set_element_class_lookup(lookup = None)
 
     Set the global default element class lookup method.
+
+    .. warning::
+
+        Setting the default element class to something other than a
+        :class:`ParserBasedElementClassLookup` will prevent
+        :meth:`~lxml.etree.XMLParser.set_element_class_lookup` from working.
+
+        Amongst other issues, this will break :mod:`lxml.html` and
+        :mod:`lxml.objectify`'s extensions as they rely on lookups configured
+        on their respective parsers.
     """
     if lookup is None or lookup._lookup_function is NULL:
         _setElementClassLookupFunction(NULL, None)


### PR DESCRIPTION
It's a bit of an attractive nuisance, as it basically turns off parser-specific class lookups, which can be surprising to people who have not looked up the mechanism in details (it certainly surprised me).

Also set `inherited-members` in the autodoc config: it's a bit dodgy but because `_BaseParser` is `@cpython.internal` it looks like autodoc can't see it at all, and so anything defined on `_BaseParser` is invisible in the new rst-based doc.

Could not test the docs because I'm hitting https://github.com/cython/cython/issues/3876, does one of the statuses provide a doc to look at?

