### PR TITLE
Include aarch64 wheel for musllinux SOABI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -61,6 +61,7 @@ jobs:
           - manylinux_2_24_i686
           - manylinux_2_24_aarch64
           - musllinux_1_1_x86_64
+          - musllinux_1_1_aarch64
           #- manylinux_2_24_ppc64le
           #- manylinux_2_24_ppc64le
           #- manylinux_2_24_s390x


### PR DESCRIPTION
In order to allow consumers to get a consistent experience in
multi-architecture installs build aarch64 wheel for musllinux SOABI as
well as manylinux