### PR TITLE
Allow cross-compiling for Windows ARM64

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -38,7 +38,7 @@ def download_and_extract_windows_binaries(destdir):
         if release_path in filename
     ]
 
-    if platform.machine() == 'ARM64':
+    if platform.machine() == 'ARM64' or os.getenv('VSCMD_ARG_TGT_ARCH') == 'arm64':
         arch = "win-arm64"
     elif sys.maxsize > 2**32:
         arch = "win64"

--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -38,6 +38,8 @@ def download_and_extract_windows_binaries(destdir):
         if release_path in filename
     ]
 
+    # Check for native ARM64 build or the environment variable that is set by
+    # Visual Studio for cross-compilation (same variable as setuptools uses)
     if platform.machine() == 'ARM64' or os.getenv('VSCMD_ARG_TGT_ARCH') == 'arm64':
         arch = "win-arm64"
     elif sys.maxsize > 2**32:

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -5,7 +5,7 @@ import os.path
 import subprocess
 from distutils.core import Extension
 from distutils.errors import CompileError, DistutilsOptionError
-from distutils.command.build_ext import build_ext as _build_ext
+from setuptools.command.build_ext import build_ext as _build_ext
 from versioninfo import get_base_dir
 
 try:

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -3,9 +3,10 @@ import io
 import os
 import os.path
 import subprocess
+
+from setuptools.command.build_ext import build_ext as _build_ext
 from distutils.core import Extension
 from distutils.errors import CompileError, DistutilsOptionError
-from setuptools.command.build_ext import build_ext as _build_ext
 from versioninfo import get_base_dir
 
 try:


### PR DESCRIPTION
When cross-compiling for Windows ARM64 (the most likely scenario), the `VSCMD_ARG_TGT_ARCH` variable is set to `arm64`. In this case, we still want to grab the ARM64 binaries instead of those matching the host (build) platform.

This variable is the same one that is used inside distutils/setuptools to tell when cross-compiling, so everything else works fine. It is set by default in a Visual Studio cross-compilation environment, but can also be set manually and setuptools will pick up the right settings by itself.