### PR TITLE
Support PEP 623 (Python 3.12)

### DIFF
--- a/src/lxml/includes/etree_defs.h
+++ b/src/lxml/includes/etree_defs.h
@@ -127,6 +127,19 @@ static PyObject* PyBytes_FromFormat(const char* format, ...) {
 #  define _lx_PySlice_GetIndicesEx(o, l, b, e, s, sl) PySlice_GetIndicesEx(((PySliceObject*)o), l, b, e, s, sl)
 #endif
 
+static const char* unicode_data_and_size(PyObject *unicode, Py_ssize_t *len) {
+#if PY_MAJOR_VERSION < 3
+    *len = PyUnicode_GET_DATA_SIZE(unicode);
+    return PyUnicode_AS_DATA(unicode);
+#else
+    if (PyUnicode_READY(unicode) < 0) {
+        return NULL;
+    }
+    *len = PyUnicode_KIND(unicode) * PyUnicode_GET_LENGTH(unicode);
+    return (const char*)PyUnicode_DATA(unicode);
+#endif
+}
+
 #ifdef WITHOUT_THREADING
 #  undef PyEval_SaveThread
 #  define PyEval_SaveThread() (NULL)

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1030,31 +1030,25 @@ cdef class _BaseParser:
         cdef int buffer_len, c_kind
         cdef const_char* c_text
         cdef const_char* c_encoding = _PY_UNICODE_ENCODING
-        cdef bint is_pep393_string = (
-            python.PEP393_ENABLED and python.PyUnicode_IS_READY(utext))
-        if is_pep393_string:
-            c_text = <const_char*>python.PyUnicode_DATA(utext)
-            py_buffer_len = python.PyUnicode_GET_LENGTH(utext)
+
+        c_text = python.unicode_data_and_size(utext, &py_buffer_len);
+        if not python.IS_PYTHON2:
             c_kind = python.PyUnicode_KIND(utext)
             if c_kind == 1:
                 c_encoding = 'ISO-8859-1'
             elif c_kind == 2:
-                py_buffer_len *= 2
                 if python.PY_BIG_ENDIAN:
                     c_encoding = 'UTF-16BE'  # actually UCS-2
                 else:
                     c_encoding = 'UTF-16LE'  # actually UCS-2
             elif c_kind == 4:
-                py_buffer_len *= 4
                 if python.PY_BIG_ENDIAN:
                     c_encoding = 'UCS-4BE'
                 else:
                     c_encoding = 'UCS-4LE'
             else:
                 assert False, f"Illegal Unicode kind {c_kind}"
-        else:
-            py_buffer_len = python.PyUnicode_GET_DATA_SIZE(utext)
-            c_text = python.PyUnicode_AS_DATA(utext)
+
         assert 0 <= py_buffer_len <= limits.INT_MAX
         buffer_len = py_buffer_len
 
@@ -1768,7 +1762,6 @@ cdef xmlDoc* _parseDoc(text, filename, _BaseParser parser) except NULL:
     cdef char* c_filename
     cdef char* c_text
     cdef Py_ssize_t c_len
-    cdef bint is_pep393_string
     if parser is None:
         parser = __GLOBAL_PARSER_CONTEXT.getDefaultParser()
     if not filename:
@@ -1776,17 +1769,13 @@ cdef xmlDoc* _parseDoc(text, filename, _BaseParser parser) except NULL:
     else:
         filename_utf = _encodeFilenameUTF8(filename)
         c_filename = _cstr(filename_utf)
+
     if isinstance(text, unicode):
-        is_pep393_string = (
-            python.PEP393_ENABLED and python.PyUnicode_IS_READY(text))
-        if is_pep393_string:
-            c_len = python.PyUnicode_GET_LENGTH(text) * python.PyUnicode_KIND(text)
-        else:
-            c_len = python.PyUnicode_GET_DATA_SIZE(text)
+        c_text = python.unicode_data_and_size(text, &c_len);
         if c_len > limits.INT_MAX:
             return (<_BaseParser>parser)._parseDocFromFilelike(
                 StringIO(text), filename, None)
-        if _PY_UNICODE_ENCODING is NULL and not is_pep393_string:
+        if python.IS_PYTHON2 and _PY_UNICODE_ENCODING is NULL:
             text = (<unicode>text).encode('utf8')
             return (<_BaseParser>parser)._parseDocFromFilelike(
                 BytesIO(text), filename, "UTF-8")

--- a/src/lxml/python.pxd
+++ b/src/lxml/python.pxd
@@ -17,10 +17,10 @@ cdef extern from "Python.h":
     cdef stdio.FILE* PyFile_AsFile(object p)
 
     # PEP 393
-    cdef bint PyUnicode_IS_READY(object u)
     cdef Py_ssize_t PyUnicode_GET_LENGTH(object u)
     cdef int PyUnicode_KIND(object u)
-    cdef void* PyUnicode_DATA(object u)
+
+    cdef bint PyUnicode_READY(object u) except -1
 
     cdef bytes PyUnicode_AsEncodedString(object u, char* encoding,
                                          char* errors)
@@ -32,9 +32,6 @@ cdef extern from "Python.h":
     cdef object PyUnicode_RichCompare(object o1, object o2, int op)
     cdef bytes PyUnicode_AsUTF8String(object ustring)
     cdef bytes PyUnicode_AsASCIIString(object ustring)
-    cdef char* PyUnicode_AS_DATA(object ustring)
-    cdef Py_ssize_t PyUnicode_GET_DATA_SIZE(object ustring)
-    cdef Py_ssize_t PyUnicode_GET_SIZE(object ustring)
     cdef bytes PyBytes_FromStringAndSize(char* s, Py_ssize_t size)
     cdef bytes PyBytes_FromFormat(char* format, ...)
     cdef Py_ssize_t PyBytes_GET_SIZE(object s)
@@ -120,6 +117,7 @@ cdef extern from "includes/etree_defs.h": # redefines some functions as macros
     cdef void* lxml_realloc(void* mem, size_t count, size_t item_size)
     cdef void lxml_free(void* mem)
     cdef void* lxml_unpack_xmldoc_capsule(object capsule, bint* is_owned) except? NULL
+    cdef char* unicode_data_and_size(object u, Py_ssize_t *len) except NULL;
     cdef bint _isString(object obj)
     cdef const_char* _fqtypename(object t)
     cdef object PY_NEW(object t)


### PR DESCRIPTION
Python 3.12 will remove PyUnicode_AS_DATA and PyUnicode_GET_DATA_SIZE.