### PR TITLE
Do not allow failures on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         env: [{ STATIC_DEPS: true }, { STATIC_DEPS: false }]
 
         include:
-          # Temporary - Allow failure on all 3.11-dev jobs until beta comes out.
+          # Temporary - Allow failure on all 3.11-dev jobs until production release comes out.
           - os: ubuntu-18.04
             python-version: 3.11-dev
             allowed_failure: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - 3.9
           - "3.10"  # quotes to avoid being interpreted as the number 3.1
           - 3.11
-          # - 3.12-dev
+          - 3.12-dev
         env: [{ STATIC_DEPS: true }, { STATIC_DEPS: false }]
 
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,15 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup python
+      - name: Setup production Python
         uses: actions/setup-python@v4
+        if: "!endsWith(matrix.python-version, '-dev')"
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup pre-release Python
+        uses: deadsnakes/action@v2
+        if: endsWith(matrix.python-version, '-dev')
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,12 @@ jobs:
             python-version: 3.9
             env: {STATIC_DEPS: true, WITH_REFNANNY: true}
             extra_hash: "-refnanny"
+            allowed_failure: true
           - os: ubuntu-18.04
             python-version: 3.11
             env: {STATIC_DEPS: true, WITH_REFNANNY: true}
             extra_hash: "-refnanny"
+            allowed_failure: true
           # Coverage setup
           - os: ubuntu-18.04
             python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - 3.9
           - "3.10"  # quotes to avoid being interpreted as the number 3.1
           - 3.11
-          - 3.12-dev
+          # - 3.12-dev
         env: [{ STATIC_DEPS: true }, { STATIC_DEPS: false }]
 
         include:
@@ -108,15 +108,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Setup production Python
+      - name: Setup Python
         uses: actions/setup-python@v4
-        if: "!endsWith(matrix.python-version, '-dev')"
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup pre-release Python
-        uses: deadsnakes/action@v2.1.1
-        if: endsWith(matrix.python-version, '-dev')
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
           - os: ubuntu-18.04
             python-version: 3.11
           - os: ubuntu-18.04
+            python-version: 3.9
+            env: {STATIC_DEPS: true, WITH_REFNANNY: true}
+            extra_hash: "-refnanny"
+          - os: ubuntu-18.04
             python-version: 3.11
             env: {STATIC_DEPS: true, WITH_REFNANNY: true}
             extra_hash: "-refnanny"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup pre-release Python
-        uses: deadsnakes/action@v2
+        uses: deadsnakes/action@v2.1.1
         if: endsWith(matrix.python-version, '-dev')
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,17 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"  # quotes to avoid being interpreted as the number 3.1
-          - "3.11-dev"
-          # - "3.12-dev"
+          - 3.11
+          - 3.12-dev
         env: [{ STATIC_DEPS: true }, { STATIC_DEPS: false }]
 
         include:
-          # Temporary - Allow failure on all 3.11-dev jobs until production release comes out.
           - os: ubuntu-18.04
-            python-version: 3.11-dev
-            allowed_failure: true
+            python-version: 3.11
           - os: ubuntu-18.04
-            python-version: 3.11-dev
+            python-version: 3.11
             env: {STATIC_DEPS: true, WITH_REFNANNY: true}
             extra_hash: "-refnanny"
-            allowed_failure: true
           # Coverage setup
           - os: ubuntu-18.04
             python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - 3.9
           - "3.10"  # quotes to avoid being interpreted as the number 3.1
           - 3.11
-          - 3.12-dev
+          # - 3.12-dev
         env: [{ STATIC_DEPS: true }, { STATIC_DEPS: false }]
 
         include:
@@ -100,12 +100,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -126,7 +126,7 @@ jobs:
         run: make html
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.extra_hash == '-docs' }}
         with:
           name: website_html
@@ -134,14 +134,14 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pycoverage_html
           path: coverage*
           if-no-files-found: ignore
 
       - name: Upload Wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.env.STATIC_DEPS == 'true' && env.COVERAGE == 'false' }}
         with:
           name: wheels-${{ runner.os }}


### PR DESCRIPTION
The current release on https://github.com/actions/python-versions/releases is `3.11.0-beta.3`

The failing test seems to be unrelated.