### PR TITLE
Correct condition for building docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: bash ./tools/ci-run.sh
 
       - name: Build docs
-        if: contains( env.EXTRA_DEPS, 'sphinx')
+        if: contains( matrix.env.EXTRA_DEPS, 'sphinx')
         run: make html
 
       - name: Upload docs


### PR DESCRIPTION
Previously the `Build Docs` step was always skipped.

I noticed this, when trying to find out, why the link [https://lxml.de/apidoc/objects.inv](https://lxml.de/apidoc/objects.inv) stopped working. This file is used by the `intersphinx` extension to Sphinx to reference objects in other documentations and should be generated by `autodoc`