### PR TITLE
Don't parse hostname from netloc manually; rely on urlsplit's result

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -490,11 +490,10 @@ class Cleaner(object):
         """
         if self.whitelist_tags is not None and el.tag not in self.whitelist_tags:
             return False
-        scheme, netloc, path, query, fragment = urlsplit(url)
-        netloc = netloc.lower().split(':', 1)[0]
-        if scheme not in ('http', 'https'):
+        parts = urlsplit(url)
+        if parts.scheme not in ('http', 'https'):
             return False
-        if netloc in self.host_whitelist:
+        if parts.hostname in self.host_whitelist:
             return True
         return False
 

--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -271,6 +271,26 @@ class CleanerTest(unittest.TestCase):
             expected,
             cleaner.clean_html(html))
 
+    def test_host_whitelist_valid(self):
+        # Frame with valid hostname in src is allowed.
+        html = '<div><iframe src="https://example.com/page"></div>'
+        expected = '<div><iframe src="https://example.com/page"></iframe></div>'
+        cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
+        self.assertEqual(expected, cleaner.clean_html(html))
+
+    def test_host_whitelist_invalid(self):
+        html = '<div><iframe src="https://evil.com/page"></div>'
+        expected = '<div></div>'
+        cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
+        self.assertEqual(expected, cleaner.clean_html(html))
+
+    def test_host_whitelist_sneaky_userinfo(self):
+        # Regression test: Don't be fooled by hostname and colon in userinfo.
+        html = '<div><iframe src="https://example.com:@evil.com/page"></div>'
+        expected = '<div></div>'
+        cleaner = Cleaner(frames=False, host_whitelist=["example.com"])
+        self.assertEqual(expected, cleaner.clean_html(html))
+
 
 def test_suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
This manual parsing of netloc can be fooled by use of a userinfo component.
SplitResult already has a hostname property.

New test `test_host_whitelist_sneaky_userinfo` fails on master.