### PR TITLE
Xpath with namespace and position

### DIFF
--- a/src/lxml/_elementpath.py
+++ b/src/lxml/_elementpath.py
@@ -87,7 +87,10 @@ def xpath_tokenizer(pattern, namespaces=None):
                 except KeyError:
                     raise SyntaxError("prefix %r not found in prefix map" % prefix)
             elif default_namespace and not parsing_attribute:
-                yield ttype, "{%s}%s" % (default_namespace, tag)
+                if tag.isnumeric():
+                    yield ttype, tag
+                else:
+                    yield ttype, "{%s}%s" % (default_namespace, tag)
             else:
                 yield token
             parsing_attribute = False

--- a/src/lxml/_elementpath.py
+++ b/src/lxml/_elementpath.py
@@ -86,11 +86,8 @@ def xpath_tokenizer(pattern, namespaces=None):
                     yield ttype, "{%s}%s" % (namespaces[prefix], uri)
                 except KeyError:
                     raise SyntaxError("prefix %r not found in prefix map" % prefix)
-            elif default_namespace and not parsing_attribute:
-                if tag.isnumeric():
-                    yield ttype, tag
-                else:
-                    yield ttype, "{%s}%s" % (default_namespace, tag)
+            elif default_namespace and not parsing_attribute and not tag.isdecimal():
+                yield ttype, "{%s}%s" % (default_namespace, tag)
             else:
                 yield token
             parsing_attribute = False

--- a/src/lxml/tests/test_elementpath.py
+++ b/src/lxml/tests/test_elementpath.py
@@ -85,6 +85,25 @@ class EtreeElementPathTestCase(HelperTestCase):
             [('', 'a'), ('[', ''), ('.', ''), ('', ''), ('=', ''), ('', ''), ('"abc"', ''), (']', '')],
             'a[. = "abc"]',
         )
+        assert_tokens(
+            [('/', ''), ('', 'a'), ('/', ''), ('', 'b'), ('/', ''), ('', 'c'), ('[', ''), ('', '1'), (']', '')],
+            '/a/b/c[1]',
+        )
+        assert_tokens(
+            [('/', ''), ('', '{nsnone}a'), ('/', ''), ('', '{nsnone}b'), ('/', ''), ('', '{nsnone}c'), ('[', ''), ('', '1'), (']', '')],
+            '/a/b/c[1]',
+            {None:'nsnone'},
+        )
+        assert_tokens(
+            [('/', ''), ('', '{nsnone}a'), ('/', ''), ('', '{nsnone}b'), ('[', ''), ('', '2'), (']', ''), ('/', ''), ('', '{nsnone}c'), ('[', ''), ('', '1'), (']', '')],
+            '/a/b[2]/c[1]',
+            {None:'nsnone'},
+        )
+        assert_tokens(
+            [('/', ''), ('', '{nsnone}a'), ('/', ''), ('', '{nsnone}b'), ('[', ''), ('', '100'), (']', '')],
+            '/a/b[100]',
+            {None:'nsnone'}
+        )
 
     def test_xpath_tokenizer(self):
         # Test the XPath tokenizer.  Copied from CPython's "test_xml_etree.py"
@@ -144,6 +163,18 @@ class EtreeElementPathTestCase(HelperTestCase):
         check("@{ns}attr", ['@', '{ns}attr'],
               {'': 'http://www.w3.org/2001/XMLSchema',
                'ns': 'http://www.w3.org/2001/XMLSchema'})
+        check("/doc/section[2]",
+              ['/', '{http://www.w3.org/2001/XMLSchema}doc', '/', '{http://www.w3.org/2001/XMLSchema}section', '[', '2', ']'],
+              {"":"http://www.w3.org/2001/XMLSchema"}
+        )
+        check("/doc/section[2]",
+              ['/', '{http://www.w3.org/2001/XMLSchema}doc', '/', '{http://www.w3.org/2001/XMLSchema}section', '[', '2', ']'],
+              {None:"http://www.w3.org/2001/XMLSchema"}
+        )
+        check("/ns:doc/ns:section[2]",
+              ['/', '{http://www.w3.org/2001/XMLSchema}doc', '/', '{http://www.w3.org/2001/XMLSchema}section', '[', '2', ']'],
+              {"ns":"http://www.w3.org/2001/XMLSchema"}
+        )
 
     def test_find(self):
         """


### PR DESCRIPTION
I noticed that it is not possible to use `elem.find` or `elem.findall` with an xpath that contains position indices if the method is called with the `namespaces` argument.
This behavior has also been reported in [Bug #1873886](https://bugs.launchpad.net/lxml/+bug/1873886).

It appears that during the tokenization of the xpath, the numbers are treated as tags, i.e. they are concatenated with the default namespace (during function calls with namespaces). This results in a wrong path imo.
For example:
```py
>>> from lxml import etree
>>> doc = etree.XML("""
      <foo xmlns="http://example.com/foo">
        <bar>baz</bar>
      </foo>""")
>>> path = "./bar[1]"
>>> doc.find(path, namespaces={None:"http://example.com/foo"})
None
```
The target element is not found here because the path that is used is effectively:
`./{http://example.com/foo}bar[{http://example.com/foo}1]`

Changes:
- I added a check during the tokenization of the xpath to determine whether the processed `tag` is a number to avoid concatenation with the namespace.