### PR TITLE
AppVeyor CI: Update to Visual Studio 2022 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 environment:
   matrix:


### PR DESCRIPTION
This PR updates the AppVeyor configuration to use the Visual Studio 2022 image.

Update 2022-11-07: The Python 3.11 part of this PR has moved to a new PR, #360.