### PR TITLE
Fix wheel building for ARM Mac

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -416,11 +416,18 @@ def configure_darwin_env(env_setup):
     # configure target architectures on MacOS-X (x86_64 only, by default)
     major_version, minor_version = tuple(map(int, platform.mac_ver()[0].split('.')[:2]))
     if major_version > 7:
-        env_default = {
-            'CFLAGS': "-arch x86_64 -O2",
-            'LDFLAGS': "-arch x86_64",
-            'MACOSX_DEPLOYMENT_TARGET': "10.6"
-        }
+        if platform.mac_ver()[2] == "arm64":
+            env_default = {
+                'CFLAGS': "-arch arm64 -O2",
+                'LDFLAGS': "-arch arm64",
+                'MACOSX_DEPLOYMENT_TARGET': "10.6"
+            }
+        else:
+            env_default = {
+                'CFLAGS': "-arch x86_64 -O2",
+                'LDFLAGS': "-arch x86_64",
+                'MACOSX_DEPLOYMENT_TARGET': "10.6"
+            }
         env_default.update(os.environ)
         env_setup['env'] = env_default
 


### PR DESCRIPTION
This PR partially fix building the lxml wheel on the new Macs.

For some reason I still need to override `ARCHFLAGS="-arch arm64"` to allow it to link it properly.