### PR TITLE
AppVeyor CI: Add Python 3.11 jobs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ image: Visual Studio 2019
 
 environment:
   matrix:
+  - python: 311
+  - python: 311-x64
   - python: 310
   - python: 310-x64
   - python: 39
@@ -19,6 +21,10 @@ environment:
   - python: 36-x64
   - python: 35
   - python: 35-x64
+
+  - python: 311
+    arch: arm64
+    env: STATIC_DEPS=true
   - python: 310
     arch: arm64
     env: STATIC_DEPS=true


### PR DESCRIPTION
AppVeyor deployed new Windows images with Python 3.11 support (https://github.com/appveyor/ci/issues/3844), which means we can use it to build Python 3.11 Windows wheels for lxml. This PR adds three Python 3.11 jobs to the matrix, for the `x86`, `x86-64` and `arm64` platforms

Part of [Bug #1977998](https://bugs.launchpad.net/lxml/+bug/1977998). Partly replaces #355.

I tested the jobs on my branch, and the [workflow passes](https://ci.appveyor.com/project/EwoutH/lxml/builds/45304917).

I would suggest after this PR, to backport it to the 4.9 maintenance branch and release a new 4.9.2 version which includes these Python 3.11 Windows wheels.