### PR TITLE
GitHub Action: python3.11 -m pip install lxml

### DIFF
--- a/.github/workflows/python3.11_-m_pip_install_lxml.yml
+++ b/.github/workflows/python3.11_-m_pip_install_lxml.yml
@@ -1,3 +1,7 @@
+# GitHub Action to prove a failure still exists...
+# * lxml still cannot be successfully installed on Python 3.11 on Windows.
+# When this GitHub Action passes then it can be deleted.
+
 name: pip_install_lxml
 on:
   pull_request:
@@ -22,7 +26,11 @@ jobs:
           sudo apt-get install -y libxml2 libxslt-dev
       - run: pip install --upgrade pip
       - run: pip install --upgrade cython wheel
-      - run: pip install . || true  # This still fails!
+      - run: pip install .  # Trying to prove a failure (a negative)
+      - if: success()  # Reverse success and failure.
+        run: exit 1  # Install has succeed so this GitHub Action can be deleted.
+      - if: failure()
+        run: exit 0  # lxml still fails on Python 3.11 on Windows
   from_pypi:
     strategy:
       fail-fast: false
@@ -34,4 +42,8 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install --upgrade pip wheel
-      - run: pip install lxml || true  # This still fails!
+      - run: pip install lxml  # Trying to prove a failure (a negative)
+      - if: success()  # Reverse success and failure.
+        run: exit 1  # Install has succeed so this GitHub Action can be deleted.
+      - if: failure()
+        run: exit 0  # lxml still fails on Python 3.11 on Windows

--- a/.github/workflows/python3.11_-m_pip_install_lxml.yml
+++ b/.github/workflows/python3.11_-m_pip_install_lxml.yml
@@ -1,0 +1,36 @@
+name: pip_install_lxml
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+jobs:
+  from_repo:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2 libxslt-dev
+      - run: pip install --upgrade pip
+      - run: pip install --upgrade cython wheel
+      - run: pip install .
+  from_pypi:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install --upgrade pip wheel
+      - run: pip install lxml

--- a/.github/workflows/python3.11_-m_pip_install_lxml.yml
+++ b/.github/workflows/python3.11_-m_pip_install_lxml.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: |
+      - if: startsWith(matrix.os, 'ubuntu')
+        run: |
           sudo apt-get update
           sudo apt-get install -y libxml2 libxslt-dev
       - run: pip install --upgrade pip

--- a/.github/workflows/python3.11_-m_pip_install_lxml.yml
+++ b/.github/workflows/python3.11_-m_pip_install_lxml.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]  # [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -22,16 +22,16 @@ jobs:
           sudo apt-get install -y libxml2 libxslt-dev
       - run: pip install --upgrade pip
       - run: pip install --upgrade cython wheel
-      - run: pip install .
+      - run: pip install . || true  # This still fails!
   from_pypi:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]  # [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
       - run: pip install --upgrade pip wheel
-      - run: pip install lxml
+      - run: pip install lxml || true  # This still fails!


### PR DESCRIPTION
Installing lxml on Python 3.11 works on Linux and macOS but not yet on Windows.

This _temporary_ GitHub Action demonstrates how installations fail:
* [ ] On Windows, `pip install lxml` from this repo
* [ ] On Windows, `pip install lxml` [from PyPI](https://pypi.org/project/lxml)

This could run on `workflow_dispatch` instead of on `push` and `pull_request` but then I would not have the rights to run it.