### PR TITLE
Fix build failed on windows server 2022

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -133,7 +133,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2019]
         #os: [macos-10.15, windows-latest]
         #os: [macos-10.15, macOS-M1]
         #os: [macos-10.15]


### PR DESCRIPTION
Hello,
I was looking since 3.11 release a wheel for my windows OS. Since yesterday's commit, it looked almost working except an issue with Visual Studio 2022. I was actually using it when installing via pip and also break on my local machine.

Tested few workflows on a branch and just realized someone had the same fix already 😄 (https://github.com/lxml/lxml/pull/356#issuecomment-1324905890).

Hopefully a wheel can be published on pypi before waiting for the next lxml release :)