### PR TITLE
Make resolve_entities require opt-in

### DIFF
--- a/doc/FAQ.txt
+++ b/doc/FAQ.txt
@@ -1082,6 +1082,9 @@ question.
 How do I use lxml safely as a web-service endpoint?
 ---------------------------------------------------
 
+Good on you for finding this FAQ, but lxml make using XML in
+web-services safe by default.
+
 XML based web-service endpoints are generally subject to several
 types of attacks if they allow some kind of untrusted input.
 From the point of view of the underlying XML tool, the most

--- a/doc/parsing.txt
+++ b/doc/parsing.txt
@@ -162,7 +162,7 @@ Available boolean keyword arguments:
 * strip_cdata - replace CDATA sections by normal text content (on by
   default)
 
-* resolve_entities - replace entities by their text value (on by
+* resolve_entities - inject and expand system entities (off by
   default)
 
 * huge_tree - disable security restrictions and support very deep trees

--- a/src/lxml/iterparse.pxi
+++ b/src/lxml/iterparse.pxi
@@ -44,7 +44,7 @@ cdef class iterparse:
      - remove_pis: discard processing instructions
      - strip_cdata: replace CDATA sections by normal text content (default: True)
      - compact: safe memory for short text content (default: True)
-     - resolve_entities: replace entities by their text value (default: True)
+     - resolve_entities: inject and expand system entities (default: False)
      - huge_tree: disable security restrictions and support very deep trees
                   and very long text content (only affects libxml2 2.7+)
      - html: parse input as HTML (default: XML)
@@ -67,7 +67,7 @@ cdef class iterparse:
     def __init__(self, source, events=(u"end",), *, tag=None,
                  attribute_defaults=False, dtd_validation=False,
                  load_dtd=False, no_network=True, remove_blank_text=False,
-                 compact=True, resolve_entities=True, remove_comments=False,
+                 compact=True, resolve_entities=False, remove_comments=False,
                  remove_pis=False, strip_cdata=True, encoding=None,
                  html=False, recover=None, huge_tree=False, collect_ids=True,
                  XMLSchema schema=None):

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1478,7 +1478,7 @@ _XML_DEFAULT_PARSE_OPTIONS = (
     )
 
 cdef class XMLParser(_FeedParser):
-    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, schema: XMLSchema =None, huge_tree=False, remove_blank_text=False, resolve_entities=True, remove_comments=False, remove_pis=False, strip_cdata=True, collect_ids=True, target=None, compact=True)
+    u"""XMLParser(self, encoding=None, attribute_defaults=False, dtd_validation=False, load_dtd=False, no_network=True, ns_clean=False, recover=False, schema: XMLSchema =None, huge_tree=False, remove_blank_text=False, resolve_entities=False, remove_comments=False, remove_pis=False, strip_cdata=True, collect_ids=True, target=None, compact=True)
 
     The XML parser.
 
@@ -1508,7 +1508,7 @@ cdef class XMLParser(_FeedParser):
     - strip_cdata        - replace CDATA sections by normal text content (default: True)
     - compact            - save memory for short text content (default: True)
     - collect_ids        - use a hash table of XML IDs for fast access (default: True, always True with DTD validation)
-    - resolve_entities   - replace entities by their text value (default: True)
+    - resolve_entities   - inject and expand system entities (default: False)
     - huge_tree          - disable security restrictions and support very deep trees
                            and very long text content (only affects libxml2 2.7+)
 


### PR DESCRIPTION
Please forgive me if my attempt to be helpful feels ungreatful - I'm probably feeling frustrated or insecure having just read up on  https://bugs.launchpad.net/swift/+bug/1998625 ... and then to realize how long other people have been dealing with this https://bugs.launchpad.net/keystone/+bug/1100282 ... which makes it feel even worse.  Like I *SHOULD* have known.  But I didn't.

I remember when the log4j/JNDI thing was a big fire, it seemed like the security commnity decided that it would be very difficult to patch all the applications that consume this feature without knowning or understanding how it worked - so the library interface should be updated to change the default.  Maybe this is only superficially similar.  I don't think they even did a major version bump, and I guess XML parsing is hardly as ubiquitous as logging.

But I do see a hint of some precedent in this project - https://github.com/lxml/lxml/commit/1a1031638330f508d3c61be7fb38fc41f8bd768a

Do you think it would be better if the default resolve_entities kwarg could change?