### PR TITLE
Add token permissions to wheels.yml

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,9 +4,14 @@ on:
   release:
     types: [created]
 
+permissions: {}
+
 jobs:
   sdist:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v3
@@ -46,6 +51,9 @@ jobs:
 
   Linux:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     strategy:
       # Allows for matrix sub-jobs to fail without canceling the rest
@@ -155,6 +163,10 @@ jobs:
             python-version: 2.7  # needs older image
 
     runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
     env: { LIBXML2_VERSION: 2.10.3, LIBXSLT_VERSION: 1.1.37, MACOSX_DEPLOYMENT_TARGET: 11.0 }
 
     steps:


### PR DESCRIPTION
Related to https://bugs.launchpad.net/lxml/+bug/2020137

As mentioned in the bug report, this PR adds minimal permissions to the wheels.yml workflow. This helps protect the project from supply-chain attacks.