### PR TITLE
Fix crash due to order of initialization for threading on Windows with shared libxml2 2.11.4

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -142,14 +142,14 @@ cdef struct qname:
     const_xmlChar* c_name
     python.PyObject* href
 
+# initialize parser (and threading)
+xmlparser.xmlInitParser()
+
 # global per-thread setup
 tree.xmlThrDefIndentTreeOutput(1)
 tree.xmlThrDefLineNumbersDefaultValue(1)
 
 _initThreadLogging()
-
-# initialize parser (and threading)
-xmlparser.xmlInitParser()
 
 # filename encoding
 cdef bytes _FILENAME_ENCODING = (sys.getfilesystemencoding() or sys.getdefaultencoding() or 'ascii').encode("UTF-8")


### PR DESCRIPTION
This fixes an Access Violation on Windows when using a shared build of libxml2 2.11.4.

Stacktrace:

 	ntdll.dll!RtlpWaitOnCriticalSection()  + 0xa6 Bytes	
 	ntdll.dll!RtlpEnterCriticalSectionContended()  + 0x1c4 Bytes	
 	ntdll.dll!RtlEnterCriticalSection()  + 0x42 Bytes	
	libxml2.dll!xmlRMutexLock(_xmlRMutex * tok=0x0000000002fea170)  Zeile 234	C
 	libxml2.dll!xmlThrDefIndentTreeOutput(int v=0)  Zeile 934	C
 	etree.pyd!00000000037fc566() 	
 	python27.dll!_PyImport_LoadDynamicModule(char * name=0x0000000002fe4408, char * pathname=0x000000005a49c660, _iobuf * fp=0x0000000002839880)  Zeile 54	C

libxml2 changed the mutex initialization in this commit: https://gitlab.gnome.org/GNOME/libxml2/-/commit/65d381f32c0d2cb2361055fddbd5c4a9119031d1

xmlThrDefIndentTreeOutput tries to use the global Mutex, but this is only initialized by xmlInitParser(), so it crashes due to wrong initialization order.