### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+Please submit the report through the
+[Launchpad bug-tracker](https://bugs.launchpad.net/lxml/+filebug) (you may need to
+create an account and log in). Make sure to mark the "🔒 This bug is a security
+vulnerability" checkbox before submitting the report. This ensures the bug can only be
+seen by the security group.
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a few maintainers on a reasonable-effort basis. As such,
+we ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Related to https://bugs.launchpad.net/lxml/+bug/2023080.

This PR adds a security policy. The policy simply points users to use Launchpad and select the checkbox if they've found a security vulnerability.