### PR TITLE
fix invalid escape sequences

### DIFF
--- a/benchmark/bench_etree.py
+++ b/benchmark/bench_etree.py
@@ -7,7 +7,7 @@ from benchbase import (with_attributes, with_text, onlylib,
                        serialized, children, nochange)
 
 TEXT  = "some ASCII text"
-UTEXT = u"some klingon: \F8D2"
+UTEXT = u"some klingon: \uF8D2"
 
 ############################################################
 # Benchmarks

--- a/benchmark/benchbase.py
+++ b/benchmark/benchbase.py
@@ -17,7 +17,7 @@ def exec_(code, glob):
 TREE_FACTOR = 1 # increase tree size with '-l / '-L' cmd option
 
 _TEXT  = "some ASCII text" * TREE_FACTOR
-_UTEXT = u"some klingon: \F8D2" * TREE_FACTOR
+_UTEXT = u"some klingon: \uF8D2" * TREE_FACTOR
 _ATTRIBUTES = {
     '{attr}test1' : _TEXT,
     '{attr}test2' : _TEXT,

--- a/doc/mklatex.py
+++ b/doc/mklatex.py
@@ -24,7 +24,7 @@ RST2LATEX_OPTIONS = " ".join([
 htmlnsmap = {"h" : "http://www.w3.org/1999/xhtml"}
 
 replace_invalid = re.compile(r'[-_/.\s\\]').sub
-replace_content = re.compile("\{[^\}]*\}").sub
+replace_content = re.compile(r"\{[^\}]*\}").sub
 
 replace_epydoc_macros = re.compile(r'(,\s*amssymb|dvips\s*,\s*)').sub
 replace_rst_macros = re.compile(r'(\\usepackage\{color}|\\usepackage\[[^]]*]\{hyperref})').sub
@@ -167,7 +167,7 @@ def tex_postprocess(src_path, dest_path, want_header=False, process_line=noop):
         if skipping(l):
             # To-Do minitoc instead of tableofcontents
             continue
-        elif "\hypertarget{old-versions}" in l:
+        elif r"\hypertarget{old-versions}" in l:
             break
         elif "listcnt0" in l:
             l = l.replace("listcnt0", counter_text)

--- a/doc/update_performance_results.py
+++ b/doc/update_performance_results.py
@@ -2,7 +2,7 @@ import operator
 import re
 
 _parse_result_line = re.compile(
-    "\s*(?P<library>\w+):\s*(?P<name>\w+)\s+\((?P<config>[-\w]+\s[\w,]+)\s*\)\s+(?P<time>[0-9.]+\s+msec/pass)"
+    r"\s*(?P<library>\w+):\s*(?P<name>\w+)\s+\((?P<config>[-\w]+\s[\w,]+)\s*\)\s+(?P<time>[0-9.]+\s+msec/pass)"
 ).match
 
 _make_key = operator.itemgetter('library', 'name', 'config')

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ extra_options['packages'] = [
 
 def setup_extra_options():
     is_interesting_package = re.compile('^(libxml|libxslt|libexslt)$').match
-    is_interesting_header = re.compile('^(zconf|zlib|.*charset)\.h$').match
+    is_interesting_header = re.compile(r'^(zconf|zlib|.*charset)\.h$').match
 
     def extract_files(directories, pattern='*'):
         def get_files(root, dir_path, files):


### PR DESCRIPTION
these will become SyntaxErrors in future versions of python

___

I found these by doing this:

```bash
python3 -Werror -m compileall .
```

also by doing this:

```console
$ git ls-files -- '*.py' | xargs flake8 | grep W605
benchmark/bench_etree.py:10:25: W605 invalid escape sequence '\F'
benchmark/benchbase.py:20:26: W605 invalid escape sequence '\F'
doc/mklatex.py:27:31: W605 invalid escape sequence '\{'
doc/mklatex.py:27:35: W605 invalid escape sequence '\}'
doc/mklatex.py:27:39: W605 invalid escape sequence '\}'
doc/mklatex.py:170:15: W605 invalid escape sequence '\h'
doc/update_performance_results.py:5:6: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:21: W605 invalid escape sequence '\w'
doc/update_performance_results.py:5:26: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:38: W605 invalid escape sequence '\w'
doc/update_performance_results.py:5:42: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:45: W605 invalid escape sequence '\('
doc/update_performance_results.py:5:60: W605 invalid escape sequence '\w'
doc/update_performance_results.py:5:64: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:67: W605 invalid escape sequence '\w'
doc/update_performance_results.py:5:73: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:76: W605 invalid escape sequence '\)'
doc/update_performance_results.py:5:78: W605 invalid escape sequence '\s'
doc/update_performance_results.py:5:97: W605 invalid escape sequence '\s'
setup.py:117:64: W605 invalid escape sequence '\.'
```