### PR TITLE
Fix CI caching/upload with STATIC_DEPS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Cache [libs]
         uses: actions/cache@v3
-        if: ${{ matrix.env.STATIC_DEPS == 'true' }}
+        if: matrix.env.STATIC_DEPS
         with:
           path: |
             libs/*.xz
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload Wheel
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.env.STATIC_DEPS == 'true' }}
+        if: matrix.env.STATIC_DEPS
         with:
           name: wheels-${{ runner.os }}
           path: dist/*.whl


### PR DESCRIPTION
CI does not appear to work as intended - for example, none of the CI cases currently appear to respect the "STATIC_DEPS" setting, (e.g. not that no wheel is uploaded where `STATIC_DEPS` is intended to be true: e.g. https://github.com/lxml/lxml/actions/runs/5287691371/jobs/9568495615

~~Github Actions doesn't allow matrix values to be structured objects (I believe they are always strings, even if they look like numbers or booleans) and doesn't seem to automatically update the variable environment from matrix.env.VARNAME.~~

~~Instead I changed the variables to use the naming convention `env-VARNAME` and merged them into the job-level variable environment. This makes the CI work as seemingly intended.~~

~~I considered using a structured value with the [`toJSON`/`fromJSON`](https://docs.github.com/en/actions/learn-github-actions/expressions#tojson) functions but this is less easy to understand and more error-prone.~~

The comparison in the if-statement `matrix.os.STATIC_DEPS == 'true'` is false when given the boolean value `true`.

It's not clear to me whether `matrix.env` can indeed be an `object` or only a `string`. As documented, [only strings are allowed](https://docs.github.com/en/actions/learn-github-actions/contexts#matrix-context), but I [filed an issue requesting clarification](https://github.com/github/docs/issues/26469).