### PR TITLE
Make Unicode recovery test work with upcoming libxml2 2.12

### DIFF
--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -693,7 +693,7 @@ cdef xmlDoc* _handleParseResult(_ParserContext context,
             # An encoding error occurred and libxml2 switched from UTF-8
             # input to (undecoded) Latin-1, at some arbitrary point in the
             # document.  Better raise an error than allowing for a broken
-            # tree with mixed encodings.
+            # tree with mixed encodings. This is fixed in libxml2 2.12.
             well_formed = 0
         elif recover or (c_ctxt.wellFormed and
                          c_ctxt.lastError.level < xmlerror.XML_ERR_ERROR):

--- a/src/lxml/tests/test_unicode.py
+++ b/src/lxml/tests/test_unicode.py
@@ -167,7 +167,11 @@ class EncodingsTestCase(HelperTestCase):
     def test_illegal_utf8_recover(self):
         data = _bytes('<test>\x80\x80\x80</test>', encoding='iso8859-1')
         parser = etree.XMLParser(recover=True)
-        self.assertRaises(etree.XMLSyntaxError, etree.fromstring, data, parser)
+        if etree.LIBXML_VERSION >= (2, 12, 0):
+            tree = etree.fromstring(data, parser)
+            self.assertEqual('\ufffd\ufffd\ufffd', tree.text)
+        else:
+            self.assertRaises(etree.XMLSyntaxError, etree.fromstring, data, parser)
 
     def _test_encoding(self, encoding, xml_encoding_name=None):
         foo = """<?xml version='1.0' encoding='%s'?>\n<tag attrib='123'></tag>""" % (


### PR DESCRIPTION
When encountering encoding errors, the upcoming version of libxml2 won't switch to ISO-8859-1 but replace illegal bytes with U+FFFD Replacement Character.