### PR TITLE
Avoid usage of unittest.makeSuite, removed from Python 3.13

### DIFF
--- a/src/lxml/html/tests/test_clean.py
+++ b/src/lxml/html/tests/test_clean.py
@@ -296,5 +296,5 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([make_doctest('test_clean.txt')])
     suite.addTests([make_doctest('test_clean_embed.txt')])
-    suite.addTests(unittest.makeSuite(CleanerTest))
+    suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(CleanerTest))
     return suite

--- a/src/lxml/html/tests/test_elementsoup.py
+++ b/src/lxml/html/tests/test_elementsoup.py
@@ -118,7 +118,7 @@ b'''<!DOCTYPE html PUBLIC "-//IETF//DTD HTML//EN">
 def test_suite():
     suite = unittest.TestSuite()
     if BS_INSTALLED:
-        suite.addTests([unittest.makeSuite(SoupParserTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(SoupParserTestCase)])
         if sys.version_info[0] < 3:
             suite.addTests([make_doctest('../../../../doc/elementsoup.txt')])
     return suite

--- a/src/lxml/tests/test_builder.py
+++ b/src/lxml/tests/test_builder.py
@@ -62,7 +62,7 @@ class BuilderTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(BuilderTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(BuilderTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_classlookup.py
+++ b/src/lxml/tests/test_classlookup.py
@@ -394,8 +394,8 @@ class ClassLookupTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ProxyTestCase)])
-    suite.addTests([unittest.makeSuite(ClassLookupTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ProxyTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ClassLookupTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_css.py
+++ b/src/lxml/tests/test_css.py
@@ -64,5 +64,5 @@ def test_suite():
 
     import lxml.cssselect
     suite.addTests(doctest.DocTestSuite(lxml.cssselect))
-    suite.addTests([unittest.makeSuite(CSSTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(CSSTestCase)])
     return suite

--- a/src/lxml/tests/test_doctestcompare.py
+++ b/src/lxml/tests/test_doctestcompare.py
@@ -125,7 +125,7 @@ class DoctestCompareTest(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(DoctestCompareTest)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(DoctestCompareTest)])
     return suite
 
 

--- a/src/lxml/tests/test_dtd.py
+++ b/src/lxml/tests/test_dtd.py
@@ -422,7 +422,7 @@ class ETreeDtdTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeDtdTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeDtdTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/validation.txt')])
     return suite

--- a/src/lxml/tests/test_elementpath.py
+++ b/src/lxml/tests/test_elementpath.py
@@ -293,8 +293,8 @@ class EtreeElementPathTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(EtreeElementPathTestCase)])
-    #suite.addTests([unittest.makeSuite(ElementTreeElementPathTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(EtreeElementPathTestCase)])
+    #suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreeElementPathTestCase)])
     return suite
 
 

--- a/src/lxml/tests/test_elementtree.py
+++ b/src/lxml/tests/test_elementtree.py
@@ -4992,22 +4992,22 @@ if cElementTree:
 def test_suite():
     suite = unittest.TestSuite()
     if etree:
-        suite.addTests([unittest.makeSuite(ETreeTestCase)])
-        suite.addTests([unittest.makeSuite(ETreePullTestCase)])
-        suite.addTests([unittest.makeSuite(ETreeElementSlicingTest)])
-        suite.addTests([unittest.makeSuite(ETreeC14NTest)])
-        suite.addTests([unittest.makeSuite(ETreeC14N2WriteTest)])
-        suite.addTests([unittest.makeSuite(ETreeC14N2TostringTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreePullTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeElementSlicingTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeC14NTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeC14N2WriteTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeC14N2TostringTest)])
     if ElementTree:
-        suite.addTests([unittest.makeSuite(ElementTreeTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreeTestCase)])
         if ElementTreePullTestCase:
-            suite.addTests([unittest.makeSuite(ElementTreePullTestCase)])
+            suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreePullTestCase)])
         if ElementTreeC14NTest:
-            suite.addTests([unittest.makeSuite(ElementTreeC14NTest)])
-        suite.addTests([unittest.makeSuite(ElementTreeElementSlicingTest)])
+            suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreeC14NTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreeElementSlicingTest)])
     if cElementTree:
-        suite.addTests([unittest.makeSuite(CElementTreeTestCase)])
-        suite.addTests([unittest.makeSuite(CElementTreeElementSlicingTest)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(CElementTreeTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(CElementTreeElementSlicingTest)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_errors.py
+++ b/src/lxml/tests/test_errors.py
@@ -70,7 +70,7 @@ class ErrorTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ErrorTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ErrorTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -5580,13 +5580,13 @@ class XMLPullParserTest(unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeOnlyTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeXIncludeTestCase)])
-    suite.addTests([unittest.makeSuite(ElementIncludeTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeC14NTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeWriteTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeErrorLogTest)])
-    suite.addTests([unittest.makeSuite(XMLPullParserTest)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeOnlyTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXIncludeTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementIncludeTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeC14NTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeWriteTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeErrorLogTest)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(XMLPullParserTest)])
 
     # add original doctests from ElementTree selftest modules
     from . import selftest, selftest2

--- a/src/lxml/tests/test_external_document.py
+++ b/src/lxml/tests/test_external_document.py
@@ -98,7 +98,7 @@ class ExternalDocumentTestCase(HelperTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     if sys.platform != 'win32':
-        suite.addTests([unittest.makeSuite(ExternalDocumentTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ExternalDocumentTestCase)])
     return suite
 
 

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -679,7 +679,7 @@ class HtmlParserTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(HtmlParserTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(HtmlParserTestCase)])
     return suite
 
 

--- a/src/lxml/tests/test_http_io.py
+++ b/src/lxml/tests/test_http_io.py
@@ -117,7 +117,7 @@ class HttpIOTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(HttpIOTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(HttpIOTestCase)])
     return suite
 
 

--- a/src/lxml/tests/test_incremental_xmlfile.py
+++ b/src/lxml/tests/test_incremental_xmlfile.py
@@ -660,12 +660,12 @@ class AsyncXmlFileTestCase(HelperTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTests([
-        unittest.makeSuite(BytesIOXmlFileTestCase),
-        unittest.makeSuite(TempXmlFileTestCase),
-        unittest.makeSuite(TempPathXmlFileTestCase),
-        unittest.makeSuite(SimpleFileLikeXmlFileTestCase),
-        unittest.makeSuite(HtmlFileTestCase),
-        unittest.makeSuite(AsyncXmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(BytesIOXmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TempXmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(TempPathXmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(SimpleFileLikeXmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(HtmlFileTestCase),
+        unittest.defaultTestLoader.loadTestsFromTestCase(AsyncXmlFileTestCase),
     ])
     return suite
 

--- a/src/lxml/tests/test_io.py
+++ b/src/lxml/tests/test_io.py
@@ -363,9 +363,9 @@ if ElementTree:
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeIOTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeIOTestCase)])
     if ElementTree:
-        suite.addTests([unittest.makeSuite(ElementTreeIOTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ElementTreeIOTestCase)])
     return suite
 
 

--- a/src/lxml/tests/test_isoschematron.py
+++ b/src/lxml/tests/test_isoschematron.py
@@ -862,7 +862,7 @@ class ETreeISOSchematronTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeISOSchematronTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeISOSchematronTestCase)])
     suite.addTests(doctest.DocTestSuite(isoschematron))
     suite.addTests(
         [make_doctest('../../../doc/validation.txt')])

--- a/src/lxml/tests/test_nsclasses.py
+++ b/src/lxml/tests/test_nsclasses.py
@@ -203,7 +203,7 @@ class ETreeNamespaceClassesTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeNamespaceClassesTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeNamespaceClassesTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/element_classes.txt')])
     return suite

--- a/src/lxml/tests/test_objectify.py
+++ b/src/lxml/tests/test_objectify.py
@@ -2744,7 +2744,7 @@ class ObjectifyTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ObjectifyTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ObjectifyTestCase)])
     suite.addTests(doctest.DocTestSuite(objectify))
     suite.addTests([make_doctest('../../../doc/objectify.txt')])
     return suite

--- a/src/lxml/tests/test_pyclasslookup.py
+++ b/src/lxml/tests/test_pyclasslookup.py
@@ -344,7 +344,7 @@ class PyClassLookupTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(PyClassLookupTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(PyClassLookupTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_relaxng.py
+++ b/src/lxml/tests/test_relaxng.py
@@ -249,11 +249,11 @@ class RelaxNGCompactTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeRelaxNGTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeRelaxNGTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/validation.txt')])
     if rnc2rng is not None:
-        suite.addTests([unittest.makeSuite(RelaxNGCompactTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(RelaxNGCompactTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_sax.py
+++ b/src/lxml/tests/test_sax.py
@@ -405,8 +405,8 @@ class NSPrefixSaxTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeSaxTestCase)])
-    suite.addTests([unittest.makeSuite(NSPrefixSaxTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeSaxTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(NSPrefixSaxTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/sax.txt')])
     return suite

--- a/src/lxml/tests/test_schematron.py
+++ b/src/lxml/tests/test_schematron.py
@@ -73,7 +73,7 @@ class ETreeSchematronTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeSchematronTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeSchematronTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/validation.txt')])
     return suite

--- a/src/lxml/tests/test_threading.py
+++ b/src/lxml/tests/test_threading.py
@@ -582,8 +582,8 @@ class ThreadPipelineTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ThreadingTestCase)])
-    suite.addTests([unittest.makeSuite(ThreadPipelineTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ThreadingTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ThreadPipelineTestCase)])
     return suite
 
 if __name__ == '__main__':

--- a/src/lxml/tests/test_unicode.py
+++ b/src/lxml/tests/test_unicode.py
@@ -207,6 +207,6 @@ class EncodingsTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(UnicodeTestCase)])
-    suite.addTests([unittest.makeSuite(EncodingsTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(UnicodeTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(EncodingsTestCase)])
     return suite

--- a/src/lxml/tests/test_xmlschema.py
+++ b/src/lxml/tests/test_xmlschema.py
@@ -499,8 +499,8 @@ class ETreeXMLSchemaResolversTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeXMLSchemaTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeXMLSchemaResolversTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXMLSchemaTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXMLSchemaResolversTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/validation.txt')])
     return suite

--- a/src/lxml/tests/test_xpathevaluator.py
+++ b/src/lxml/tests/test_xpathevaluator.py
@@ -734,11 +734,11 @@ if sys.version_info[0] >= 3:
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeXPathTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeXPathClassTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXPathTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXPathClassTestCase)])
     if etree.LIBXSLT_COMPILED_VERSION >= (1,1,25):
-        suite.addTests([unittest.makeSuite(ETreeXPathExsltTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeETXPathClassTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXPathExsltTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeETXPathClassTestCase)])
     suite.addTests([doctest.DocTestSuite()])
     suite.addTests(
         [make_doctest('../../../doc/xpathxslt.txt')])

--- a/src/lxml/tests/test_xslt.py
+++ b/src/lxml/tests/test_xslt.py
@@ -2090,12 +2090,12 @@ class Py3XSLTTestCase(HelperTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTests([unittest.makeSuite(ETreeXSLTTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeEXSLTTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeXSLTExtFuncTestCase)])
-    suite.addTests([unittest.makeSuite(ETreeXSLTExtElementTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXSLTTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeEXSLTTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXSLTExtFuncTestCase)])
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(ETreeXSLTExtElementTestCase)])
     if is_python3:
-        suite.addTests([unittest.makeSuite(Py3XSLTTestCase)])
+        suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(Py3XSLTTestCase)])
     suite.addTests(
         [make_doctest('../../../doc/extensions.txt')])
     suite.addTests(


### PR DESCRIPTION
Patch generated by:

    sed -i 's/unittest.makeSuite/unittest.defaultTestLoader.loadTestsFromTestCase/g' $(grep -rl makeSuite)


No idea if this will work on Python 2, hence only opening as a draft.