### PR TITLE
Hash-pin GitHub Actions, set up grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,12 +151,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 1
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         if: startsWith(matrix.python-version, '3.')
         with:
           python-version: ${{ matrix.python-version }}
@@ -179,14 +179,14 @@ jobs:
           ln -s /usr/local/bin/glibtoolize /usr/local/bin/libtoolize
 
       - name: Cache [ccache]
-        uses: pat-s/always-upload-cache@v3.0.11
+        uses: pat-s/always-upload-cache@9a0d1c3e1a8260b05500f9b67a5be8f2a1299819 # v3.0.11
         if: startsWith(runner.os, 'Linux') || startsWith(runner.os, 'mac')
         with:
           path: ~/.ccache
           key: ${{ runner.os }}-ccache${{ matrix.extra_hash }}-${{ matrix.python-version }}-${{ hashFiles('.github/workflows/ci.yml', 'tools/ci-run.sh') }}
 
       - name: Cache [libs]
-        uses: actions/cache@v3
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         if: matrix.env.STATIC_DEPS
         with:
           path: |
@@ -205,7 +205,7 @@ jobs:
         run: make html
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: matrix.extra_hash == '-docs'
         with:
           name: website_html
@@ -213,14 +213,14 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: pycoverage_html
           path: coverage*
           if-no-files-found: ignore
 
       - name: Upload Wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: matrix.env.STATIC_DEPS
         with:
           name: wheels-${{ runner.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,10 +35,10 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
         python-version: "3.x"
 
@@ -53,19 +53,19 @@ jobs:
       env: { STATIC_DEPS: false }
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: dist/*.tar.gz
 
     - name: Upload sdist
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: sdist
         path: dist/*.tar.gz
 
     - name: Upload website
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: website
         path: doc/html
@@ -132,10 +132,10 @@ jobs:
             pyversion: "cp312*"
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
         python-version: "3.11"
 
@@ -146,7 +146,7 @@ jobs:
       run: python -m pip install -r requirements.txt
 
     - name: Cache [libs]
-      uses: actions/cache@v3
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         path: |
           libs/*.xz
@@ -163,13 +163,13 @@ jobs:
       env: { STATIC_DEPS: true, PYTHON_BUILD_VERSION: "${{ matrix.pyversion }}" }
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: wheelhouse/*/*-m*linux*.whl  # manylinux / musllinux
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: wheels-${{ matrix.image }}
         path: wheelhouse/*/*-m*linux*.whl  # manylinux / musllinux
@@ -212,10 +212,10 @@ jobs:
     env: { LIBXML2_VERSION: 2.11.5, LIBXSLT_VERSION: 1.1.38, MACOSX_DEPLOYMENT_TARGET: 11.0 }
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       if: startsWith(matrix.python-version, '3.') || startsWith(matrix.python-version, 'pypy')
       with:
         python-version: ${{ matrix.python-version }}
@@ -230,7 +230,7 @@ jobs:
       run: python -m pip install setuptools wheel -r requirements.txt
 
     - name: Cache [libs]
-      uses: actions/cache@v3
+      uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
       with:
         path: |
           libs/*.xz
@@ -243,13 +243,13 @@ jobs:
       env: { STATIC_DEPS: true, RUN_TESTS: true }
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: dist/lxml-*.whl
 
     - name: Upload wheels
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: wheels-${{ matrix.os }}
         path: dist/lxml-*.whl


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/lxml/+bug/2043502.

This PR hash-pins GitHub Actions used in the CI/CD workflows, hardening the project against broken or malicious releases.

It also configures dependabot to use grouped updates, with a single PR updating all Actions with new versions.

Regardless of whether you merge this PR, I also suggest enabling Dependabot's security updates in the repo [Settings > Code security & analysis](https://github.com/lxml/lxml/settings/security_analysis). Dependabot will then send emergency PRs as soon as a dependency (an Action or the Cython in the requirements.txt) has a known vulnerability.