### PR TITLE
MNT: support for Python without PEP393 dropped by Cython

### DIFF
--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1029,8 +1029,7 @@ cdef class _BaseParser:
         cdef int buffer_len, c_kind
         cdef const_char* c_text
         cdef const_char* c_encoding = _PY_UNICODE_ENCODING
-        cdef bint is_pep393_string = (
-            python.PEP393_ENABLED and python.PyUnicode_IS_READY(utext))
+        cdef bint is_pep393_string = (python.PyUnicode_IS_READY(utext))
         if is_pep393_string:
             c_text = <const_char*>python.PyUnicode_DATA(utext)
             py_buffer_len = python.PyUnicode_GET_LENGTH(utext)
@@ -1776,8 +1775,7 @@ cdef xmlDoc* _parseDoc(text, filename, _BaseParser parser) except NULL:
         filename_utf = _encodeFilenameUTF8(filename)
         c_filename = _cstr(filename_utf)
     if isinstance(text, unicode):
-        is_pep393_string = (
-            python.PEP393_ENABLED and python.PyUnicode_IS_READY(text))
+        is_pep393_string = (python.PyUnicode_IS_READY(text))
         if is_pep393_string:
             c_len = python.PyUnicode_GET_LENGTH(text) * python.PyUnicode_KIND(text)
         else:

--- a/src/lxml/python.pxd
+++ b/src/lxml/python.pxd
@@ -2,9 +2,6 @@ from libc cimport stdio
 from libc.string cimport const_char
 cimport cython
 
-cdef extern from *:
-    cdef bint PEP393_ENABLED "CYTHON_PEP393_ENABLED"
-
 cdef extern from "Python.h":
     """
     #if defined(CYTHON_PEP393_ENABLED) && CYTHON_PEP393_ENABLED


### PR DESCRIPTION
This is the minimal change to get it to cythonize / compile again.

I am not sure if `python.PyUnicode_IS_READY(utext))` can ever be false (which would me some dead code could be ripped out), if the local variable should be renamed, and if dropping below py3.7 is on the table for lxml.

xref: https://github.com/cython/cython/pull/5801