### PR TITLE
Disable external entity resolution (XXE) by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -49,6 +49,11 @@ Bugs fixed
 Other changes
 -------------
 
+* LP#1742885: lxml no longer expands external entities (XXE) by default to prevent
+  the security risk of loading arbitrary files and URLs.  If this feature is needed,
+  it can be enabled in a backwards compatible way by using a parser with the option
+  ``resolve_entities=True``.  The new default is ``resolve_entities='internal'``.
+
 * With libxml2 2.10.4 and later (as provided by the lxml 5.0 binary wheels),
   parsing HTML tags with "prefixes" no longer builds a namespace dictionary
   in ``nsmap`` but considers the ``prefix:name`` string the actual tag name.

--- a/doc/FAQ.txt
+++ b/doc/FAQ.txt
@@ -1105,9 +1105,9 @@ useless for the data commonly sent through web services and
 can simply be disabled, which rules out several types of
 denial of service attacks at once.  This also involves an attack
 that reads local files from the server, as XML entities can be
-defined to expand into their content.   Consequently, version
-1.2 of the SOAP standard explicitly disallows entity references
-in the XML stream.
+defined to expand into the content of external resources.
+Consequently, version 1.2 of the SOAP standard explicitly
+disallows entity references in the XML stream.
 
 To disable entity expansion, use an XML parser that is configured
 with the option ``resolve_entities=False``.  Then, after (or
@@ -1115,7 +1115,11 @@ while) parsing the document, use ``root.iter(etree.Entity)`` to
 recursively search for entity references.  If it contains any,
 reject the entire input document with a suitable error response.
 In lxml 3.x, you can also use the new DTD introspection API to
-apply your own restrictions on input documents.
+apply your own restrictions on input documents.  Since version 5.x,
+lxml disables the expansion of external entities (XXE) by default.
+If you really want to allow loading external files into XML documents
+using this functionality, you have to explicitly set
+``resolve_entities=True``.
 
 Another attack to consider is compression bombs.  If you allow
 compressed input into your web service, attackers can try to send

--- a/src/lxml/includes/xmlparser.pxd
+++ b/src/lxml/includes/xmlparser.pxd
@@ -78,7 +78,7 @@ cdef extern from "libxml/tree.h" nogil:
         charactersSAXFunc               characters
         cdataBlockSAXFunc               cdataBlock
         referenceSAXFunc                reference
-        getEntitySAXFunc	            getEntity
+        getEntitySAXFunc                getEntity
         commentSAXFunc                  comment
         processingInstructionSAXFunc	processingInstruction
         startDocumentSAXFunc            startDocument

--- a/src/lxml/includes/xmlparser.pxd
+++ b/src/lxml/includes/xmlparser.pxd
@@ -3,7 +3,7 @@ from libc.string cimport const_char
 from lxml.includes.tree cimport (
     xmlDoc, xmlNode, xmlEntity, xmlDict, xmlDtd, xmlChar, const_xmlChar)
 from lxml.includes.tree cimport xmlInputReadCallback, xmlInputCloseCallback
-from lxml.includes.xmlerror cimport xmlError, xmlStructuredErrorFunc
+from lxml.includes.xmlerror cimport xmlError, xmlStructuredErrorFunc, xmlErrorLevel
 
 
 cdef extern from "libxml/parser.h" nogil:
@@ -54,6 +54,7 @@ cdef extern from "libxml/parser.h" nogil:
 cdef extern from "libxml/tree.h" nogil:
     ctypedef struct xmlParserInput:
         int line
+        int col
         int length
         const_xmlChar* base
         const_xmlChar* cur
@@ -153,6 +154,8 @@ cdef extern from "libxml/parser.h" nogil:
         int inSubset
         int charset
         xmlParserInput* input
+        int inputNr
+        xmlParserInput* inputTab[]
 
     ctypedef enum xmlParserOption:
         XML_PARSE_RECOVER = 1 # recover on errors
@@ -214,6 +217,12 @@ cdef extern from "libxml/parser.h" nogil:
                                    char* buffer, int size,
                                    char* filename, const_char* encoding,
                                    int options)
+
+    cdef void xmlErrParser(xmlParserCtxt* ctxt, xmlNode* node,
+                           int domain, int code, xmlErrorLevel level,
+                           const xmlChar *str1, const xmlChar *str2, const xmlChar *str3,
+                           int int1, const char *msg, ...)
+
 
 # iterparse:
 

--- a/src/lxml/includes/xmlparser.pxd
+++ b/src/lxml/includes/xmlparser.pxd
@@ -1,7 +1,7 @@
 from libc.string cimport const_char
 
 from lxml.includes.tree cimport (
-    xmlDoc, xmlNode, xmlDict, xmlDtd, xmlChar, const_xmlChar)
+    xmlDoc, xmlNode, xmlEntity, xmlDict, xmlDtd, xmlChar, const_xmlChar)
 from lxml.includes.tree cimport xmlInputReadCallback, xmlInputCloseCallback
 from lxml.includes.xmlerror cimport xmlError, xmlStructuredErrorFunc
 
@@ -47,6 +47,8 @@ cdef extern from "libxml/parser.h" nogil:
 
     ctypedef void (*referenceSAXFunc)(void * ctx, const_xmlChar* name) noexcept
 
+    ctypedef xmlEntity* (*getEntitySAXFunc)(void* ctx, const_xmlChar* name) noexcept
+
     cdef int XML_SAX2_MAGIC
 
 cdef extern from "libxml/tree.h" nogil:
@@ -76,6 +78,7 @@ cdef extern from "libxml/tree.h" nogil:
         charactersSAXFunc               characters
         cdataBlockSAXFunc               cdataBlock
         referenceSAXFunc                reference
+        getEntitySAXFunc	            getEntity
         commentSAXFunc                  comment
         processingInstructionSAXFunc	processingInstruction
         startDocumentSAXFunc            startDocument
@@ -232,6 +235,8 @@ cdef extern from "libxml/parser.h" nogil:
         const_char * URL, const_char * ID, xmlParserCtxt* context) noexcept
     cdef xmlExternalEntityLoader xmlGetExternalEntityLoader()
     cdef void xmlSetExternalEntityLoader(xmlExternalEntityLoader f)
+
+    cdef xmlEntity* xmlSAX2GetEntity(void* ctxt, const_xmlChar* name) noexcept
 
 # DTDs:
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1798,7 +1798,7 @@ class ETreeOnlyTestCase(HelperTestCase):
                 <!ENTITY my_external_entity SYSTEM "%s">
             ]>
             <doc>&my_external_entity;</doc>
-            ''' % entity_file
+            ''' % path2url(entity_file)
             root = fromstring(xml, parser)
 
         self.assertEqual(root[0].tag, Entity)
@@ -1813,7 +1813,7 @@ class ETreeOnlyTestCase(HelperTestCase):
                 <!ENTITY my_failing_external_entity SYSTEM "%s">
             ]>
             <doc>&my_failing_external_entity;</doc>
-            ''' % entity_file
+            ''' % path2url(entity_file)
 
             try:
                 fromstring(xml)

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1759,8 +1759,8 @@ class ETreeOnlyTestCase(HelperTestCase):
         parser = self.etree.XMLParser(resolve_entities=True)
 
         with tempfile.NamedTemporaryFile(suffix='.xml') as tmpfile:
-            tmpfile.write(b'<evil>XML</evil>')
-            tmpfile.flush()
+            with open(tmpfile.name, "wb") as f:
+                f.write(b'<evil>XML</evil>')
 
             xml = '''
             <!DOCTYPE doc [
@@ -1806,7 +1806,6 @@ class ETreeOnlyTestCase(HelperTestCase):
         except self.etree.XMLSyntaxError as exc:
             self.assertIn("my_external_entity", str(exc))
             self.assertTrue(exc.error_log)
-            print(exc.error_log.last_error)
             # Depending on the libxml2 version, we get different errors here,
             # not necessarily the one that lxml produced. But it should fail either way.
             self.assertIn("my_external_entity", exc.error_log.last_error.message)

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1805,6 +1805,12 @@ class ETreeOnlyTestCase(HelperTestCase):
             fromstring(xml)
         except self.etree.XMLSyntaxError as exc:
             self.assertIn("my_external_entity", str(exc))
+            self.assertTrue(exc.error_log)
+            print(exc.error_log.last_error)
+            # Depending on the libxml2 version, we get different errors here,
+            # not necessarily the one that lxml produced. But it should fail either way.
+            self.assertIn("my_external_entity", exc.error_log.last_error.message)
+            self.assertEqual(5, exc.error_log.last_error.line)
         else:
             self.assertTrue(False, "XMLSyntaxError was not raised")
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1764,7 +1764,6 @@ class ETreeOnlyTestCase(HelperTestCase):
             entity_file = os.path.join(temp_dir, "entity.xml")
             with open(entity_file, 'wb') as tmpfile:
                 tmpfile.write(b'<evil>XML</evil>')
-                tmpfile.flush()
 
             xml = '''
             <!DOCTYPE doc [

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1762,7 +1762,7 @@ class ETreeOnlyTestCase(HelperTestCase):
         temp_dir = tempfile.mkdtemp()
         try:
             entity_file = os.path.join(temp_dir, "entity.xml")
-            with entity_file as tmpfile:
+            with open(entity_file, 'wb') as tmpfile:
                 tmpfile.write(b'<evil>XML</evil>')
                 tmpfile.flush()
 

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1800,8 +1800,13 @@ class ETreeOnlyTestCase(HelperTestCase):
         ]>
         <doc>&my_external_entity;</doc>
         ''' % fileUrlInTestDir("test.xml")
-        self.assertRaisesRegex(
-            self.etree.XMLSyntaxError, ".*my_external_entity.*", fromstring, xml)
+
+        try:
+            fromstring(xml)
+        except self.etree.XMLSyntaxError as exc:
+            self.assertIn("my_external_entity", str(exc))
+        else:
+            self.assertTrue(False, "XMLSyntaxError was not raised")
 
     def test_entity_restructure(self):
         xml = _bytes('''<!DOCTYPE root [ <!ENTITY nbsp "&#160;"> ]>

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1754,7 +1754,7 @@ class ETreeOnlyTestCase(HelperTestCase):
                           tostring(root))
 
     def test_entity_parse_external(self):
-        parse = self.etree.parse
+        fromstring = self.etree.fromstring
         tostring = self.etree.tostring
         parser = self.etree.XMLParser(resolve_entities=True)
 
@@ -1767,10 +1767,9 @@ class ETreeOnlyTestCase(HelperTestCase):
                 <!ENTITY my_external_entity SYSTEM "%s">
             ]>
             <doc>&my_external_entity;</doc>
-            ''' % tmpfile.name
-            tree = parse(StringIO(xml), parser)
+            ''' % path2url(tmpfile.name)
+            root = fromstring(xml, parser)
 
-        root = tree.getroot()
         self.assertEqual(_bytes('<doc><evil>XML</evil></doc>'),
                           tostring(root))
         self.assertEqual(root.tag, 'doc')
@@ -1779,7 +1778,7 @@ class ETreeOnlyTestCase(HelperTestCase):
         self.assertEqual(root[0].tail, None)
 
     def test_entity_parse_external_no_resolve(self):
-        parse = self.etree.parse
+        fromstring = self.etree.fromstring
         parser = self.etree.XMLParser(resolve_entities=False)
         Entity = self.etree.Entity
         xml = '''
@@ -1787,23 +1786,22 @@ class ETreeOnlyTestCase(HelperTestCase):
             <!ENTITY my_external_entity SYSTEM "%s">
         ]>
         <doc>&my_external_entity;</doc>
-        ''' % fileInTestDir("test.xml")
+        ''' % fileUrlInTestDir("test.xml")
 
-        tree = parse(StringIO(xml), parser)
-        root = tree.getroot()
+        root = fromstring(xml, parser)
         self.assertEqual(root[0].tag, Entity)
         self.assertEqual(root[0].text, "&my_external_entity;")
 
     def test_entity_parse_no_external_default(self):
-        parse = self.etree.parse
+        fromstring = self.etree.fromstring
         xml = '''
         <!DOCTYPE doc [
             <!ENTITY my_external_entity SYSTEM "%s">
         ]>
         <doc>&my_external_entity;</doc>
-        ''' % fileInTestDir("test.xml")
+        ''' % fileUrlInTestDir("test.xml")
         self.assertRaisesRegex(
-            self.etree.XMLSyntaxError, ".*my_external_entity.*", parse, StringIO(xml))
+            self.etree.XMLSyntaxError, ".*my_external_entity.*", fromstring, xml)
 
     def test_entity_restructure(self):
         xml = _bytes('''<!DOCTYPE root [ <!ENTITY nbsp "&#160;"> ]>

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -1759,8 +1759,8 @@ class ETreeOnlyTestCase(HelperTestCase):
         parser = self.etree.XMLParser(resolve_entities=True)
 
         with tempfile.NamedTemporaryFile(suffix='.xml') as tmpfile:
-            with open(tmpfile.name, "wb") as f:
-                f.write(b'<evil>XML</evil>')
+            tmpfile.write(b'<evil>XML</evil>')
+            tmpfile.flush()
 
             xml = '''
             <!DOCTYPE doc [


### PR DESCRIPTION
This prevents security risks that would allow loading arbitrary external files.