### PR TITLE
Update xmlerror.pxd for libxml2 2.12

### DIFF
--- a/src/lxml/includes/xmlerror.pxd
+++ b/src/lxml/includes/xmlerror.pxd
@@ -840,7 +840,7 @@ cdef extern from "libxml/xmlerror.h" nogil:
 
     ctypedef void (*xmlGenericErrorFunc)(void* ctxt, char* msg, ...) noexcept
     ctypedef void (*xmlStructuredErrorFunc)(void* userData,
-                                            xmlError* error) noexcept
+                                            const xmlError* error) noexcept
 
     cdef void xmlSetGenericErrorFunc(
         void* ctxt, xmlGenericErrorFunc func)


### PR DESCRIPTION
They made this const I believe.

see https://github.com/GNOME/libxml2/blob/d2b55a7a029c47ebcfa6ede88331d38f90d3eb24/include/libxml/xmlerror.h#L864