### PR TITLE
Enable subscripting generic types in annotations.

### DIFF
--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -227,6 +227,10 @@ class ElementMaker:
     def __getattr__(self, tag):
         return partial(self, tag)
 
+    # Allow subscripting ElementMaker in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 # create factory object
 E = ElementMaker()

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -1947,6 +1947,10 @@ cdef public class _ElementTree [ type LxmlElementTreeType,
             # so what ...
             return self
 
+    # Allow subscripting ElementTree in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
     # not in ElementTree
     @property
     def docinfo(self) -> DocInfo:

--- a/src/lxml/extensions.pxi
+++ b/src/lxml/extensions.pxi
@@ -733,6 +733,11 @@ cdef class _ElementUnicodeResult(unicode):
     def is_attribute(self):
         return self.attrname is not None
 
+    # Allow subscripting _ElementUnicodeResult in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
+
 cdef object _elementStringResultFactory(string_value, _Element parent,
                                         attrname, bint is_tail):
     result = _ElementUnicodeResult(string_value)

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1638,6 +1638,10 @@ cdef class XMLParser(_FeedParser):
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding, resolve_external)
 
+    # Allow subscripting XMLParser in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 cdef class XMLPullParser(XMLParser):
     """XMLPullParser(self, events=None, *, tag=None, **kwargs)
@@ -1806,6 +1810,10 @@ cdef class HTMLParser(_FeedParser):
         _BaseParser.__init__(self, parse_options, True, schema,
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding)
+
+    # Allow subscripting HTMLParser in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
 
 
 cdef HTMLParser __DEFAULT_HTML_PARSER

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -152,6 +152,10 @@ class ElementTreeContentHandler(ContentHandler):
 
     ignorableWhitespace = characters
 
+    # Allow subscripting sax.ElementTreeContentHandler in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 class ElementTreeProducer:
     """Produces SAX events for an element and children.

--- a/src/lxml/tests/test_annotations.py
+++ b/src/lxml/tests/test_annotations.py
@@ -1,0 +1,45 @@
+"""
+Test typing annotations.
+"""
+
+
+import unittest
+import sys
+from io import BytesIO
+
+from .common_imports import etree
+from .common_imports import HelperTestCase
+from lxml import builder, sax
+
+
+class TypingTestCase(HelperTestCase):
+    """Typing test cases
+    """
+
+    def test_subscripted_generic(self):
+        # Test that all generic types can be subscripted.
+        # Based on PEP 560 implemented in python 3.7.
+
+        if sys.version_info[:2] >= (3, 7):
+            etree._ElementTree[int]
+            xml_parser: etree.XMLParser[int]
+            html_parser: etree.HTMLParser[int]
+            element_maker: builder.ElementMaker[int]
+            element_tree_content_handler: sax.ElementTreeContentHandler[int]
+            id_dict: etree._IDDict[int]
+            element_unicode_result: etree._ElementUnicodeResult[int]
+
+        # Subscripting etree._Element should fail with the error:
+        # TypeError: 'type' object is not subscriptable
+        # Make sure that the test works and it is indeed failing.
+        self.assertRaises(TypeError, lambda: etree._Element[int])
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(TypingTestCase)])
+    return suite
+
+
+if __name__ == '__main__':
+    print('to test use test.py %s' % __file__)

--- a/src/lxml/xmlid.pxi
+++ b/src/lxml/xmlid.pxi
@@ -95,6 +95,10 @@ cdef class _IDDict:
     def get(self, id_name):
         return self[id_name]
 
+    # Allow subscripting _IDDict in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
     def __contains__(self, id_name):
         cdef tree.xmlID* c_id
         id_utf = _utf8(id_name)


### PR DESCRIPTION
Some classes like `lxml.etree._ElementTree` are generic types that can contain different kinds of elements. The type of these elements has to be specified in type annotations. For example:

```
element_tree: lxml.etree._ElementTree[lxml.etree._Element]
```

This requires adding a `__class_getitem__` class method to these class, as specified in PEP 560. This commit adds these class methods.

The list of generic types in lxml was taken from:

https://github.com/abelcheung/types-lxml/wiki/Using-specialised-class-directly