### PR TITLE
Fix test_elementtree with Expat 2.6.0

### DIFF
--- a/src/lxml/tests/test_elementtree.py
+++ b/src/lxml/tests/test_elementtree.py
@@ -10,6 +10,7 @@ import copy
 import io
 import operator
 import os
+import pyexpat
 import re
 import sys
 import textwrap
@@ -4383,29 +4384,44 @@ class _XMLPullParserTest(unittest.TestCase):
         self.assertEqual([(action, elem.tag) for action, elem in events],
                          expected)
 
-    def test_simple_xml(self):
-        for chunk_size in (None, 1, 5):
-            #with self.subTest(chunk_size=chunk_size):
-                parser = self.etree.XMLPullParser()
-                self.assert_event_tags(parser, [])
-                self._feed(parser, "<!-- comment -->\n", chunk_size)
-                self.assert_event_tags(parser, [])
-                self._feed(parser,
-                           "<root>\n  <element key='value'>text</element",
-                           chunk_size)
-                self.assert_event_tags(parser, [])
-                self._feed(parser, ">\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'element')])
-                self._feed(parser, "<element>text</element>tail\n", chunk_size)
-                self._feed(parser, "<empty-element/>\n", chunk_size)
-                self.assert_event_tags(parser, [
-                    ('end', 'element'),
-                    ('end', 'empty-element'),
-                    ])
-                self._feed(parser, "</root>\n", chunk_size)
-                self.assert_event_tags(parser, [('end', 'root')])
-                root = self._close_and_return_root(parser)
-                self.assertEqual(root.tag, 'root')
+    def test_simple_xml(self, chunk_size=None):
+        parser = self.etree.XMLPullParser()
+        self.assert_event_tags(parser, [])
+        self._feed(parser, "<!-- comment -->\n", chunk_size)
+        self.assert_event_tags(parser, [])
+        self._feed(parser,
+                   "<root>\n  <element key='value'>text</element",
+                   chunk_size)
+        self.assert_event_tags(parser, [])
+        self._feed(parser, ">\n", chunk_size)
+        self.assert_event_tags(parser, [('end', 'element')])
+        self._feed(parser, "<element>text</element>tail\n", chunk_size)
+        self._feed(parser, "<empty-element/>\n", chunk_size)
+        self.assert_event_tags(parser, [
+            ('end', 'element'),
+            ('end', 'empty-element'),
+            ])
+        self._feed(parser, "</root>\n", chunk_size)
+        self.assert_event_tags(parser, [('end', 'root')])
+        root = self._close_and_return_root(parser)
+        self.assertEqual(root.tag, 'root')
+
+    def test_simple_xml_chunk_1(self):
+        if self.etree is not etree and pyexpat.version_info >= (2, 6, 0):
+            raise unittest.SkipTest(
+                "Feeding the parser by too small chunks defers parsing"
+            )
+        self.test_simple_xml(chunk_size=1)
+
+    def test_simple_xml_chunk_5(self):
+        if self.etree is not etree and pyexpat.version_info >= (2, 6, 0):
+            raise unittest.SkipTest(
+                "Feeding the parser by too small chunks defers parsing"
+            )
+        self.test_simple_xml(chunk_size=5)
+
+    def test_simple_xml_chunk_22(self):
+        self.test_simple_xml(chunk_size=22)
 
     def test_feed_while_iterating(self):
         parser = self.etree.XMLPullParser()


### PR DESCRIPTION
Feeding the parser by too small chunks defers parsing to prevent CVE-2023-52425. Future versions of Expat may be more reactive.

Heavily inspired by https://github.com/python/cpython/commit/4a08e7b3431cd32a0daf22a33421cd3035343dc4

We cannot use a @fails_with_expat_2_6_0 decorator
because the test passes in ETreePullTestCase.

Co-authored-by: @serhiy-storchaka