### PR TITLE
FIX: Allow multiple inlined image data links in html clean

### DIFF
--- a/src/lxml/html/clean.py
+++ b/src/lxml/html/clean.py
@@ -54,7 +54,7 @@ _looks_like_tag_content = re.compile(
 # All kinds of schemes besides just javascript: that can cause
 # execution:
 _find_image_dataurls = re.compile(
-    r'data:image/(.+);base64,', re.I).findall
+    r'data:image/(.+?);base64,', re.I).findall
 _possibly_malicious_schemes = re.compile(
     r'(javascript|jscript|livescript|vbscript|data|about|mocha):',
     re.I).findall


### PR DESCRIPTION
Add a lazy quantifier in the regex `_find_image_dataurls` to match as few characters as possible,
to make it stop at the first occurence of `;base64,`

e.g.
```py
>>> _find_image_dataurls = re.compile(r'data:image/(.+);base64,', re.I).findall
>>> _find_image_dataurls('<div style="background: url(data:image/jpeg;base64,foo); background-image: url(data:image/jpeg;base64,foo);"></div>')
['jpeg;base64,foo); background-image: url(data:image/jpeg']
```

```py
>>> _find_image_dataurls = re.compile(r'data:image/(.+?);base64,', re.I).findall
>>> _find_image_dataurls('<div style="background: url(data:image/jpeg;base64,foo); background-image: url(data:image/jpeg;base64,foo);"></div>')
['jpeg', 'jpeg']
```

This allows to have multiple image data links on the same line, which happens for instance in inline styles.

Without this change, `_has_javascript_scheme` returns `True` because the count of safe image urls is lower than the number of possible malicious scheme.
Then, the whole style is dropped as considered malicious.