### PR TITLE
Skip test_feedparser_data if lxml_html_clean is not available

### DIFF
--- a/src/lxml/html/tests/test_feedparser_data.py
+++ b/src/lxml/html/tests/test_feedparser_data.py
@@ -9,7 +9,11 @@ import unittest
 from lxml.tests.common_imports import doctest
 from lxml.doctestcompare import LHTMLOutputChecker
 
-from lxml.html.clean import clean, Cleaner
+try:
+    from lxml.html.clean import clean, Cleaner
+    html_clean_available = True
+except ImportError:
+    html_clean_available = False
 
 feed_dirs = [
     os.path.join(os.path.dirname(__file__), 'feedparser-data'),
@@ -80,6 +84,11 @@ class FeedTestCase(unittest.TestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
+
+    if not html_clean_available:
+        print("Skipping tests in feedparser_data - external lxml_html_clean package is not installed")
+        return suite
+
     for dir in feed_dirs:
         for fn in os.listdir(dir):
             fn = os.path.join(dir, fn)


### PR DESCRIPTION
This is useful mostly for distributors shipping lxml without lxml_html_clean.

I did it the same way as it's done for cssselect in test_css.py.