### PR TITLE
Remove check for ']]>' in CDATA class, add test

### DIFF
--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -3144,10 +3144,7 @@ cdef class CDATA:
     """
     cdef bytes _utf8_data
     def __cinit__(self, data):
-        _utf8_data = _utf8(data)
-        if b']]>' in _utf8_data:
-            raise ValueError, "']]>' not allowed inside CDATA"
-        self._utf8_data = _utf8_data
+        self._utf8_data = _utf8(data)
 
 
 def Entity(name):

--- a/src/tests/test_etree.py
+++ b/src/tests/test_etree.py
@@ -1962,6 +1962,20 @@ class ETreeOnlyTestCase(HelperTestCase):
 
         self.assertEqual(['test'], root.xpath('//text()'))
 
+    def test_cdata_split_cdend(self):
+        # Tests that existing ']]>' in CDATA is split to 'escape' it
+        CDATA = self.etree.CDATA
+        Element = self.etree.Element
+        tostring = self.etree.tostring
+
+        root = Element("root")
+        root.text = CDATA('test]]>')
+
+        self.assertEqual('test]]>',
+                          root.text)
+        self.assertEqual(b'<root><![CDATA[test]]]]><![CDATA[>]]></root>',
+                          tostring(root))
+
     # TypeError in etree, AssertionError in ElementTree;
     def test_setitem_assert(self):
         Element = self.etree.Element


### PR DESCRIPTION
CDATA containing CDEnd (']]>') is handled by libxml2 by splitting it into ']]' and '>'. It is no longer needed to disallow CDend. A test to ensure this is added.