### PR TITLE
Fix `KeyError` in `Schematron` When Handling Missing or Invalid Namespace Prefixes

### DIFF
--- a/src/lxml/isoschematron/__init__.py
+++ b/src/lxml/isoschematron/__init__.py
@@ -225,7 +225,7 @@ class Schematron(_etree._Validator):
         schematron = None
         if element.tag == _xml_schema_root:
             schematron = self._extract_xsd(element)
-        elif element.nsmap[element.prefix] == RELAXNG_NS:
+        elif element.nsmap.get(element.prefix) == RELAXNG_NS:
             # RelaxNG does not have a single unique root element
             schematron = self._extract_rng(element)
         return schematron

--- a/src/tests/test_isoschematron.py
+++ b/src/tests/test_isoschematron.py
@@ -68,6 +68,20 @@ class ETreeISOSchematronTestCase(HelperTestCase):
         self.assertRaises(etree.SchematronParseError,
                           isoschematron.Schematron, schema)
 
+    def test_schematron_invalid_namespace_prefix(self):
+        schema = self.parse('''\
+<xml:i />
+''')
+        self.assertRaises(etree.SchematronParseError,
+                          isoschematron.Schematron, schema)
+
+    def test_schematron_missing_namespace_prefix(self):
+        schema = self.parse('''\
+<rr />
+''')
+        self.assertRaises(etree.SchematronParseError,
+                          isoschematron.Schematron, schema)
+
     def test_schematron_from_tree(self):
         schema = self.parse('''\
 <sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron">


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/lxml/+bug/2058177

Resolves an issue in the `lxml.isoschematron.Schematron` class where an unhandled KeyError was raised when `Schematron` is initialized with elements that have invalid or missing namespace prefixes. The KeyError occurred due to direct dictionary access without checking for the existence of the key.

The changes introduced here:

- Replace direct dictionary access with dict.get() to safely retrieve values from namespace maps, preventing KeyError on missing/invalid prefixes.
- Add unit tests to cover cases where schemas lack proper namespace prefixes or contain incorrect namespace prefixes.