### PR TITLE
tests: Adjust HTML tests for upcoming libxml2 changes

### DIFF
--- a/doc/parsing.txt
+++ b/doc/parsing.txt
@@ -246,7 +246,7 @@ this feature.
 
 .. sourcecode:: pycon
 
-  >>> broken_html = "<html><head><title>test<body><h1>page title</h3>"
+  >>> broken_html = "<html><head><title>test</title><body><h1>page title</h3>"
 
   >>> parser = etree.HTMLParser()
   >>> html_root   = etree.fromstring(broken_html, parser)

--- a/src/lxml/html/tests/hackers-org-data/background-image-plus.data
+++ b/src/lxml/html/tests/hackers-org-data/background-image-plus.data
@@ -1,8 +1,0 @@
-Description: I built a quick XSS fuzzer to detect any erroneous characters that are allowed after the open parenthesis but before the JavaScript directive in IE and Netscape 8.1 in secure site mode. These are in decimal but you can include hex and add padding of course. (Any of the following chars can be used: 1-32, 34, 39, 160, 8192-8.13, 12288, 65279)
-    http://ha.ckers.org/xss.html#XSS_DIV_background-image_plus
-Options: -safe_attrs_only
-Notes: As you see, the CSS gets corrupted, but I don't really care that much.
-
-<DIV STYLE="background-image: url(&#1;javascript:alert('XSS'))">text</div>
-----------
-<div style="background-image: url(">text</div>

--- a/src/lxml/html/tests/test_basic.py
+++ b/src/lxml/html/tests/test_basic.py
@@ -9,16 +9,14 @@ class TestBasicFeatures(unittest.TestCase):
         doc = html.fromstring("""
         <root>
             <!-- comment -->
-            <?pi contents ?>
             &entity;
             <el/>
         </root>
         """, base_url=base_url)
         self.assertEqual(doc.getroottree().docinfo.URL, base_url)
-        self.assertEqual(len(doc), 3)
+        self.assertEqual(len(doc), 2)
         self.assertIsInstance(doc[0], html.HtmlComment)
-        self.assertIsInstance(doc[1], html.HtmlProcessingInstruction)
-        self.assertIsInstance(doc[2], html.HtmlElement)
+        self.assertIsInstance(doc[1], html.HtmlElement)
         for child in doc:
             # base_url makes sense on all nodes (kinda) whereas `classes` or
             # `get_rel_links` not really

--- a/src/lxml/tests/test_etree.py
+++ b/src/lxml/tests/test_etree.py
@@ -4576,24 +4576,24 @@ class ETreeOnlyTestCase(HelperTestCase):
         tostring = self.etree.tostring
         html = self.etree.fromstring(
             '<html><body>'
-            '<div><p>Some text<i>\r\n</i></p></div>\r\n'
+            '<div><p>Some text<i>\n</i></p></div>\n'
             '</body></html>',
             parser=self.etree.HTMLParser())
         self.assertEqual(html.tag, 'html')
         div = html.find('.//div')
-        self.assertEqual(div.tail, '\r\n')
+        self.assertEqual(div.tail, '\n')
         result = tostring(div, method='html')
         self.assertEqual(
             result,
-            b"<div><p>Some text<i>\r\n</i></p></div>\r\n")
+            b"<div><p>Some text<i>\n</i></p></div>\n")
         result = tostring(div, method='html', with_tail=True)
         self.assertEqual(
             result,
-            b"<div><p>Some text<i>\r\n</i></p></div>\r\n")
+            b"<div><p>Some text<i>\n</i></p></div>\n")
         result = tostring(div, method='html', with_tail=False)
         self.assertEqual(
             result,
-            b"<div><p>Some text<i>\r\n</i></p></div>")
+            b"<div><p>Some text<i>\n</i></p></div>")
 
     def test_standalone(self):
         tostring = self.etree.tostring

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -24,7 +24,7 @@ class HtmlParserTestCase(HelperTestCase):
 </html>
 """
     broken_html_str = (
-        b"<html><head><title>test"
+        b"<html><head><title>test</title>"
         b"<body><h1>page title</h3></p></html>")
     uhtml_str = (
         "<html><head><title>test Ã¡</title></head>"
@@ -373,7 +373,7 @@ class HtmlParserTestCase(HelperTestCase):
 
     def test_html_iterparse_broken(self):
         iterparse = self.etree.iterparse
-        f = BytesIO(b'<head><title>TEST></head><p>P<br></div>')
+        f = BytesIO(b'<head><title>TEST></title></head><p>P<br></div>')
 
         iterator = iterparse(f, html=True)
         self.assertEqual(None, iterator.root)


### PR DESCRIPTION
Starting with 2.14.0, the tokenizer in libxml2's HTML parser conforms to HTML5 which means that some documents will be parsed differently. The following changes affect the lxml test suite:

- <title> is an RCDATA element, meaning that it can only be closed with a "</title>" string. This is easy to fix by closing the element correctly. Unfortunately, libxml2's old behavior is used to document and test how the parser previously recovered from malformed HTML.

- Newlines are normalized now and U+000D CARRIAGE RETURN (CR) is stripped from the input.

- ASCII control chars are now allowed.

- Processing instructions are parsed as bogus comments.

Instead of trying to check for different libxml2 versions, I simply deleted parts of some tests.