### PR TITLE
remove flat_namespace link flag on darwin

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -352,13 +352,6 @@ def cflags(static_cflags):
             if not possible_cflag.startswith('-I'):
                 result.append(possible_cflag)
 
-    if sys.platform in ('darwin',):
-        for opt in result:
-            if 'flat_namespace' in opt:
-                break
-        else:
-            result.append('-flat_namespace')
-
     return result
 
 def define_macros():


### PR DESCRIPTION
darwin uses a two-level namespace by default and linking with flat_namespace changes the runtime symbol lookup algorithm to resolve symbols at runtime with the first definition found rather than the dylib used at link time. flat_namespace causes issues when more than one library is loaded into the address space.