### PR TITLE
Add docstrings relating to functions involving parser context to parser.pxi

### DIFF
--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -981,10 +981,10 @@ cdef class _BaseParser:
         return 0
 
     cdef xmlparser.xmlParserCtxt* _newParserCtxt(self) except NULL:
-    """
-    This method calls into libxml to configure the libxml2-level parser context,
-    among other things.
-    """
+        """
+        This method calls into libxml to configure the libxml2-level parser context,
+        among other things.
+        """
         cdef xmlparser.xmlParserCtxt* c_ctxt
         if self._for_html:
             c_ctxt = htmlparser.htmlCreateMemoryParserCtxt('dummy', 5)

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -712,13 +712,9 @@ cdef xmlDoc* _handleParseResult(_ParserContext context,
         c_ctxt.myDoc = NULL
 
     if result is not NULL:
-        # In libxml2 logic that has already run, the libxml2-level wellFormed (camel
-        # case), which starts at 1, is set to 0 if the parser MAY be able to parse the
-        # document despite errors that libxml2 has to work through. So, here in this
-        # if/elif/else block, lxml-level well_formed (snake case) follows the same
-        # pattern; lxml decides whether to set well_formed from 1 to 0, in part based on
-        # that libxml2 wellFormed. However, lxml chooses to customise its version of the
-        # variable using additional criteria in this if/elif/else block.
+        # "wellFormed" in libxml2 is 0 if the parser found fatal errors. It still returns a
+        # parse result document if 'recover=True'. Here, we determine if we can present
+        # the document to the user or consider it incorrect or broken enough to raise an error.
         if (context._validator is not None and
                 not context._validator.isvalid()):
             well_formed = 0  # actually not 'valid', but anyway ...


### PR DESCRIPTION
I wrote docstrings for a number of functions in `parser.pxi`. Since the docs [said](https://lxml.de/lxml-source-howto.html#lxml-etree) `parser.pxi` is "definitely not the right place to start reading lxml's source code," I thought it would be helpful to make it more accessible to newcomers.

In particular, I focused on functions that involved the parser context. This includes the context at the lxml/Cython level and the libxml2/C level. I wrote these based on notes I took as I was reading through `parser.pxi` for the first time and learning how lxml's parser wraps libxml2. I include a little bit of detail on libxml2 internals because it appears coupled to lxml and I don't anticipate any changes soon to the libxml2 code I mention.

Feedback is welcome.