### PR TITLE
iterparse: ignore strip_cdata with HTML

### DIFF
--- a/src/lxml/iterparse.pxi
+++ b/src/lxml/iterparse.pxi
@@ -42,7 +42,8 @@ cdef class iterparse:
      - remove_blank_text: discard blank text nodes
      - remove_comments: discard comments
      - remove_pis: discard processing instructions
-     - strip_cdata: replace CDATA sections by normal text content (default: True)
+     - strip_cdata: replace CDATA sections by normal text content (default: 
+       True for XML, ignored otherwise)
      - compact: safe memory for short text content (default: True)
      - resolve_entities: replace entities by their text value (default: True)
      - huge_tree: disable security restrictions and support very deep trees
@@ -97,7 +98,6 @@ cdef class iterparse:
                 remove_blank_text=remove_blank_text,
                 remove_comments=remove_comments,
                 remove_pis=remove_pis,
-                strip_cdata=strip_cdata,
                 no_network=no_network,
                 target=None,  # TODO
                 schema=schema,

--- a/src/lxml/tests/test_htmlparser.py
+++ b/src/lxml/tests/test_htmlparser.py
@@ -442,6 +442,46 @@ class HtmlParserTestCase(HelperTestCase):
                 ('start', root[1]), ('start', root[1][0])],
             events)
 
+    def test_html_iterparse_cdata(self):
+        import warnings
+
+        iterparse = self.etree.iterparse
+        f = BytesIO(b'<html><body><![CDATA[ foo ]]></body></html>')
+
+        with warnings.catch_warnings(record=True) as warned_novalue:
+            warnings.simplefilter("always")
+            iterator = iterparse(f, html=True, events=('start', ))
+        self.assertFalse(warned_novalue)
+
+        events = list(iterator)
+        root = iterator.root
+        self.assertNotEqual(None, root)
+        self.assertEqual(('start', root), events[0])
+
+        f.seek(0)
+        with warnings.catch_warnings(record=True) as warned_true:
+            warnings.simplefilter("always")
+            iterator = iterparse(
+                f, html=True, events=('start', ), strip_cdata=True)
+        self.assertFalse(warned_true)
+
+        events = list(iterator)
+        root = iterator.root
+        self.assertNotEqual(None, root)
+        self.assertEqual(('start', root), events[0])
+
+        f.seek(0)
+        with warnings.catch_warnings(record=True) as warned_false:
+            warnings.simplefilter("always")
+            iterator = iterparse(
+                f, html=True, events=('start', ), strip_cdata=False)
+        self.assertFalse(warned_false)
+
+        events = list(iterator)
+        root = iterator.root
+        self.assertNotEqual(None, root)
+        self.assertEqual(('start', root), events[0])
+
     def test_html_feed_parser(self):
         parser = self.etree.HTMLParser()
         parser.feed("<html><body></")


### PR DESCRIPTION
Commit b79424c deprecated the `strip_cdata` argument to the HTML parser, causing all uses of `iterparse()` to trigger its `DeprecationWarning` (due to the default `True` value). Remove the `strip_cdata` argument from the HTML parser's arguments, and document it as ignored in `iterparse()` except for XML documents.

Tests are added to `test_htmlparser.py`, I've verified that they fail on the `master` branch without this change, but pass on the PR branch.

See also: https://bugs.launchpad.net/lxml/+bug/2067707