### PR TITLE
CI: Remove ubuntu 20.04 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,6 @@ jobs:
 
           # Legacy jobs
           # ===========
-          - os: ubuntu-20.04
-            python-version: "3.6"
-            env: { STATIC_DEPS: true }  # only static
           - os: ubuntu-22.04
             python-version: "3.7"
             env: { STATIC_DEPS: true }


### PR DESCRIPTION
GitHub is shutting down the ubuntu-20.04 runners. They'll all be gone by April 1, with "brownouts" (random failures) likely to start before then.

Ref: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down