### PR TITLE
Add a note about C compiler installation to error message

### DIFF
--- a/setupinfo.py
+++ b/setupinfo.py
@@ -285,6 +285,7 @@ def print_libxml_error():
     print('Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?')
     if sys.platform in ('darwin',):
         print('Perhaps try: xcode-select --install')
+    print('Otherwise, is your C compiler installed and configured correctly?')
     print('*********************************************************************************')
 
 


### PR DESCRIPTION
I wrote an update to a hard coded error I ran into trying to build lxml. The original error suggested that the problem might be with my libxml2 installation, but in fact I hadn't installed a C compiler.