### PR TITLE
Add support for writing CDATA escaped strings in `lxml.xmlfile.write()`

### DIFF
--- a/src/lxml/serializer.pxi
+++ b/src/lxml/serializer.pxi
@@ -1573,6 +1573,15 @@ cdef class _IncrementalFileWriter:
                 else:
                     tree.xmlOutputBufferWriteEscape(self._c_out, _xcstr(bstring), NULL)
 
+            elif isinstance(content, CDATA):
+                if self._status != WRITER_IN_ELEMENT:
+                    if self._status > WRITER_IN_ELEMENT:
+                        raise LxmlSyntaxError("not in an element")
+
+                _writeNodeToBuffer(self._c_out, _createTextNode(NULL, content),
+                                   self._c_encoding, NULL, c_method,
+                                   False, False, False, False, False)
+
             elif iselement(content):
                 if self._status > WRITER_IN_ELEMENT:
                     raise LxmlSyntaxError("cannot append trailing element to complete XML document")
@@ -1585,7 +1594,7 @@ cdef class _IncrementalFileWriter:
 
             elif content is not None:
                 raise TypeError(
-                    f"got invalid input value of type {type(content)}, expected string or Element")
+                    f"got invalid input value of type {type(content)}, expected string, CDATA or Element")
             self._handle_error(self._c_out.error)
         if not self._buffered:
             tree.xmlOutputBufferFlush(self._c_out)


### PR DESCRIPTION
While refactoring a project for my workplace that utilizes lxml (specifically the incremental `xmlfile` class) to create XML export files from data streams on various REST API's, I was adding support for namespaces to my code when I ran into the same issue as this user on StackOverflow "[lmxl incremental XML serialisation repeats namespaces](https://stackoverflow.com/questions/53083828/lmxl-incremental-xml-serialisation-repeats-namespaces)"

So I converted my code from writing `Element` instances directly to using the Python `with` syntax to preserve parent node namespaces without repeating them on the child nodes (which would bloat the export file size):
Example from:
```Python
from io import BytesIO
from lxml import etree

file = BytesIO()
with etree.xmlfile(file) as xf:
    with xf.element('rss', nsmap={'g': 'http://base.google.com/ns/1.0'}):
        with xf.element('channel'):
            with xf.element('item'):
                elem = etree.Element('{http://base.google.com/ns/1.0}field1')
                elem.text = 'data 1'
                xf.write(elem)
                
                elem = etree.Element('{http://base.google.com/ns/1.0}field2')
                elem.text = 'data 2'
                xf.write(elem)

assert file.getvalue() == b'<rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><ns0:field1 xmlns:ns0="http://base.google.com/ns/1.0">data 1</ns0:field1><ns0:field2 xmlns:ns0="http://base.google.com/ns/1.0">data 2</ns0:field2></item></channel></rss>'
```

Example to:
```Python
from io import BytesIO
from lxml import etree

file = BytesIO()
with etree.xmlfile(file) as xf:
    with xf.element('rss', nsmap={'g': 'http://base.google.com/ns/1.0'}):
        with xf.element('channel'):
            with xf.element('item'):
                with xf.element('{http://base.google.com/ns/1.0}field1'):
                    xf.write('data 1')
                with xf.element('{http://base.google.com/ns/1.0}field2'):
                    xf.write('data 2')

assert file.getvalue() == b'<rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><g:field1>data 1</g:field1><g:field2>data 2</g:field2></item></channel></rss>'
```
But I found out that breaks some of my existing export files that use CDATA escaping because `lxml.xmlfile.write()` supports strings and Element nodes containing CDATA text, but doesn't support CDATA instances as direct arguments and raises  `TypeError` when one is provided.

Working code, but duplicates namespaces:
```Python
from io import BytesIO
from lxml import etree

file = BytesIO()
with etree.xmlfile(file) as xf:
    with xf.element('rss', nsmap={'g': 'http://base.google.com/ns/1.0'}):
        with xf.element('channel'):
            with xf.element('item'):
                elem = etree.Element('{http://base.google.com/ns/1.0}field1')
                elem.text = etree.CDATA('data 1')
                xf.write(elem)
                
                elem = etree.Element('{http://base.google.com/ns/1.0}field2')
                elem.text = etree.CDATA('data 2')
                xf.write(elem)

assert file.getvalue() == b'<rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><ns0:field1 xmlns:ns0="http://base.google.com/ns/1.0"><![CDATA[data 1]]></ns0:field1><ns0:field2 xmlns:ns0="http://base.google.com/ns/1.0"><![CDATA[data 2]]></ns0:field2></item></channel></rss>'
```

New code without duplicating namespaces, but raises `TypeError`:
```Python
from io import BytesIO
from lxml import etree

file = BytesIO()
with etree.xmlfile(file) as xf:
    with xf.element('rss', nsmap={'g': 'http://base.google.com/ns/1.0'}):
        with xf.element('channel'):
            with xf.element('item'):
                with xf.element('{http://base.google.com/ns/1.0}field1'):
                    xf.write(etree.CDATA('data 1'))
                with xf.element('{http://base.google.com/ns/1.0}field2'):
                    xf.write(etree.CDATA('data 2'))

assert file.getvalue() == b'<rss xmlns:g="http://base.google.com/ns/1.0"><channel><item><g:field1><![CDATA[data 1]]></g:field1><g:field2><![CDATA[data 2]]></g:field2></item></channel></rss>'
```

So this PR allows `lxml.xmlfile.write()` to write CDATA instances to maintain parity with how `Element.text` works. I've also included unit tests that also check to make sure the CDATA is output and correctly escapes the encapsulated text string(s).