### PR TITLE
Enable subscripting generic types in annotations.

### DIFF
--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -227,6 +227,10 @@ class ElementMaker:
     def __getattr__(self, tag):
         return partial(self, tag)
 
+    # Allow subscripting ElementMaker in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 # create factory object
 E = ElementMaker()

--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -229,6 +229,10 @@ class ElementMaker:
 
     # Allow subscripting ElementMaker in type annotions (PEP 560)
     def __class_getitem__(cls, item):
+        import sys
+        if sys.version_info >= (3, 9):
+            from types import GenericAlias
+            return GenericAlias(cls, item)
         return f"{cls.__name__}[{item.__name__}]"
 
 

--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -46,6 +46,13 @@ _QName = ET.QName
 from functools import partial
 
 try:
+    from types import GenericAlias as _GenericAlias
+except ImportError:
+    # Python 3.8 - we only need this as return value from "__class_getitem__"
+    def _GenericAlias(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
+try:
     basestring
 except NameError:
     basestring = str
@@ -229,11 +236,7 @@ class ElementMaker:
 
     # Allow subscripting ElementMaker in type annotions (PEP 560)
     def __class_getitem__(cls, item):
-        import sys
-        if sys.version_info >= (3, 9):
-            from types import GenericAlias
-            return GenericAlias(cls, item)
-        return f"{cls.__name__}[{item.__name__}]"
+        return _GenericAlias(cls, item)
 
 
 # create factory object

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -3342,6 +3342,10 @@ class ElementTree(ABC):
 
         return _elementTreeFactory(doc, element)
 
+    # Allow subscripting ElementTree in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 # Register _ElementTree as a virtual subclass of ElementTree
 ElementTree.register(_ElementTree)
 

--- a/src/lxml/etree.pyx
+++ b/src/lxml/etree.pyx
@@ -3315,8 +3315,11 @@ def SubElement(_Element _parent not None, _tag,
     """
     return _makeSubElement(_parent, _tag, None, None, attrib, nsmap, _extra)
 
+from typing import Generic, TypeVar
 
-class ElementTree(ABC):
+T = TypeVar("T")
+
+class ElementTree(ABC, Generic[T]):
     def __new__(cls, _Element element=None, *, file=None, _BaseParser parser=None):
         """ElementTree(element=None, file=None, parser=None)
 
@@ -3342,15 +3345,12 @@ class ElementTree(ABC):
 
         return _elementTreeFactory(doc, element)
 
-    # Allow subscripting ElementTree in type annotions (PEP 560)
-    def __class_getitem__(cls, item):
-        return f"{cls.__name__}[{item.__name__}]"
-
 # Register _ElementTree as a virtual subclass of ElementTree
 ElementTree.register(_ElementTree)
 
-# Remove "ABC" helper from module dict again
-del ABC
+# Remove "ABC" and typing helpers from module dict
+del ABC, Generic, TypeVar, T
+
 def HTML(text, _BaseParser parser=None, *, base_url=None):
     """HTML(text, parser=None, base_url=None)
 

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -3,6 +3,14 @@
 from lxml.includes cimport xmlparser
 from lxml.includes cimport htmlparser
 
+cdef object _GenericAlias
+try:
+    from types import GenericAlias as _GenericAlias
+except ImportError:
+    # Python 3.8 - we only need this as return value from "__class_getitem__"
+    def _GenericAlias(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 class ParseError(LxmlSyntaxError):
     """Syntax error while parsing an XML document.
@@ -1662,11 +1670,7 @@ cdef class XMLParser(_FeedParser):
 
     # Allow subscripting XMLParser in type annotions (PEP 560)
     def __class_getitem__(cls, item):
-        import sys
-        if sys.version_info >= (3, 9):
-            from types import GenericAlias
-            return GenericAlias(cls, item)
-        return f"{cls.__name__}[{item.__name__}]"
+        return _GenericAlias(cls, item)
 
 
 cdef class XMLPullParser(XMLParser):
@@ -1849,11 +1853,7 @@ cdef class HTMLParser(_FeedParser):
 
     # Allow subscripting HTMLParser in type annotions (PEP 560)
     def __class_getitem__(cls, item):
-        import sys
-        if sys.version_info >= (3, 9):
-            from types import GenericAlias
-            return GenericAlias(cls, item)
-        return f"{cls.__name__}[{item.__name__}]"
+        return _GenericAlias(cls, item)
 
 
 cdef HTMLParser __DEFAULT_HTML_PARSER

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1660,6 +1660,10 @@ cdef class XMLParser(_FeedParser):
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding, resolve_external)
 
+    # Allow subscripting XMLParser in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 cdef class XMLPullParser(XMLParser):
     """XMLPullParser(self, events=None, *, tag=None, **kwargs)
@@ -1838,6 +1842,10 @@ cdef class HTMLParser(_FeedParser):
         _BaseParser.__init__(self, parse_options, True, schema,
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding)
+
+    # Allow subscripting HTMLParser in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
 
 
 cdef HTMLParser __DEFAULT_HTML_PARSER

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1662,6 +1662,10 @@ cdef class XMLParser(_FeedParser):
 
     # Allow subscripting XMLParser in type annotions (PEP 560)
     def __class_getitem__(cls, item):
+        import sys
+        if sys.version_info >= (3, 9):
+            from types import GenericAlias
+            return GenericAlias(cls, item)
         return f"{cls.__name__}[{item.__name__}]"
 
 
@@ -1845,6 +1849,10 @@ cdef class HTMLParser(_FeedParser):
 
     # Allow subscripting HTMLParser in type annotions (PEP 560)
     def __class_getitem__(cls, item):
+        import sys
+        if sys.version_info >= (3, 9):
+            from types import GenericAlias
+            return GenericAlias(cls, item)
         return f"{cls.__name__}[{item.__name__}]"
 
 

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -18,6 +18,13 @@ from lxml import etree
 from lxml.etree import ElementTree, SubElement
 from lxml.etree import Comment, ProcessingInstruction
 
+try:
+    from types import GenericAlias as _GenericAlias
+except ImportError:
+    # Python 3.8 - we only need this as return value from "__class_getitem__"
+    def _GenericAlias(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 class SaxError(etree.LxmlError):
     """General SAX error.
@@ -154,11 +161,7 @@ class ElementTreeContentHandler(ContentHandler):
 
     # Allow subscripting sax.ElementTreeContentHandler in type annotions (PEP 560)
     def __class_getitem__(cls, item):
-        import sys
-        if sys.version_info >= (3, 9):
-            from types import GenericAlias
-            return GenericAlias(cls, item)
-        return f"{cls.__name__}[{item.__name__}]"
+        return _GenericAlias(cls, item)
 
 
 class ElementTreeProducer:

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -152,6 +152,10 @@ class ElementTreeContentHandler(ContentHandler):
 
     ignorableWhitespace = characters
 
+    # Allow subscripting sax.ElementTreeContentHandler in type annotions (PEP 560)
+    def __class_getitem__(cls, item):
+        return f"{cls.__name__}[{item.__name__}]"
+
 
 class ElementTreeProducer:
     """Produces SAX events for an element and children.

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -154,6 +154,10 @@ class ElementTreeContentHandler(ContentHandler):
 
     # Allow subscripting sax.ElementTreeContentHandler in type annotions (PEP 560)
     def __class_getitem__(cls, item):
+        import sys
+        if sys.version_info >= (3, 9):
+            from types import GenericAlias
+            return GenericAlias(cls, item)
         return f"{cls.__name__}[{item.__name__}]"
 
 

--- a/src/lxml/tests/test_annotations.py
+++ b/src/lxml/tests/test_annotations.py
@@ -2,6 +2,10 @@
 Test typing annotations.
 """
 
+from __future__ import annotations
+
+import inspect
+import sys
 import unittest
 
 from .common_imports import etree
@@ -21,12 +25,16 @@ def container_function_with_subscripted_types():
     ):
         pass
 
+    return function_with_subscripted_types
+
 
 def container_function_with_subscripted_private_element_tree():
     def function_with_subscripted_private_element_tree(
         _element_tree: etree._ElementTree[etree.Element],
     ):
         pass
+
+    return function_with_subscripted_private_element_tree
 
 
 class TypingTestCase(HelperTestCase):
@@ -36,13 +44,16 @@ class TypingTestCase(HelperTestCase):
     def test_subscripted_generic(self):
         # Test that all generic types can be subscripted.
         # Based on PEP 560.
-        container_function_with_subscripted_types()
+        func = container_function_with_subscripted_types()
+        inspect.get_annotations(func, eval_str=True)
 
         # Subscripting etree.Element should fail with the error:
-        # TypeError: 'type' Element is not subscriptable
+        # TypeError: 'type' _ElementTree is not subscriptable
         # Make sure that the test works and it is indeed failing.
-        with self.assertRaises(TypeError):
-            container_function_with_subscripted_private_element_tree()
+        if sys.version_info >= (3, 10):
+            with self.assertRaises(TypeError):
+                func = container_function_with_subscripted_private_element_tree()
+                inspect.get_annotations(func, eval_str=True)
 
 
 def test_suite():

--- a/src/lxml/tests/test_annotations.py
+++ b/src/lxml/tests/test_annotations.py
@@ -1,0 +1,55 @@
+"""
+Test typing annotations.
+"""
+
+import unittest
+
+from .common_imports import etree
+from .common_imports import HelperTestCase
+from lxml import builder, sax
+
+
+def container_function_with_subscripted_types():
+    # The function definition is in a container so that any errors would trigger
+    # when calling the function instead of during import.
+    def function_with_subscripted_types(
+        element_tree: etree.ElementTree[etree.Element],
+        xml_parser: etree.XMLParser[etree.Element],
+        html_parser: etree.HTMLParser[etree.Element],
+        element_maker: builder.ElementMaker[etree.Element],
+        element_tree_content_handler: sax.ElementTreeContentHandler[etree.Element],
+    ):
+        pass
+
+
+def container_function_with_subscripted_private_element_tree():
+    def function_with_subscripted_private_element_tree(
+        _element_tree: etree._ElementTree[etree.Element],
+    ):
+        pass
+
+
+class TypingTestCase(HelperTestCase):
+    """Typing test cases
+    """
+
+    def test_subscripted_generic(self):
+        # Test that all generic types can be subscripted.
+        # Based on PEP 560.
+        container_function_with_subscripted_types()
+
+        # Subscripting etree.Element should fail with the error:
+        # TypeError: 'type' Element is not subscriptable
+        # Make sure that the test works and it is indeed failing.
+        with self.assertRaises(TypeError):
+            container_function_with_subscripted_private_element_tree()
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTests([unittest.defaultTestLoader.loadTestsFromTestCase(TypingTestCase)])
+    return suite
+
+
+if __name__ == '__main__':
+    print('to test use test.py %s' % __file__)

--- a/src/lxml/tests/test_annotations.py
+++ b/src/lxml/tests/test_annotations.py
@@ -2,9 +2,8 @@
 Test typing annotations.
 """
 
-from __future__ import annotations
-
 import inspect
+import typing
 import sys
 import unittest
 
@@ -46,15 +45,37 @@ class TypingTestCase(HelperTestCase):
         # Based on PEP 560.
         func = container_function_with_subscripted_types()
         if sys.version_info >= (3, 10):
-            inspect.get_annotations(func, eval_str=True)
+            # inspect.get_annotations was added in python 3.10.
+            ann = inspect.get_annotations(func, eval_str=True)
+
+            et_ann = ann["element_tree"]
+            assert typing.get_origin(et_ann) == etree.ElementTree
+            assert typing.get_args(et_ann) == (etree.Element,)
+
+            xml_ann = ann["xml_parser"]
+            assert typing.get_origin(xml_ann) == etree.XMLParser
+            assert typing.get_args(xml_ann) == (etree.Element,)
+
+            html_ann = ann["html_parser"]
+            assert typing.get_origin(html_ann) == etree.HTMLParser
+            assert typing.get_args(html_ann) == (etree.Element,)
+
+            maker_ann = ann["element_maker"]
+            assert typing.get_origin(maker_ann) == builder.ElementMaker
+            assert typing.get_args(maker_ann) == (etree.Element,)
+
+            handler_ann = ann["element_tree_content_handler"]
+            assert typing.get_origin(handler_ann) == sax.ElementTreeContentHandler
+            assert typing.get_args(handler_ann) == (etree.Element,)
 
         # Subscripting etree.Element should fail with the error:
         # TypeError: 'type' _ElementTree is not subscriptable
         # Make sure that the test works and it is indeed failing.
-        if sys.version_info >= (3, 10):
-            with self.assertRaises(TypeError):
-                func = container_function_with_subscripted_private_element_tree()
-                inspect.get_annotations(func, eval_str=True)
+        with self.assertRaises(TypeError):
+            # TypeError should be raised here for python < 3.14:
+            func = container_function_with_subscripted_private_element_tree()
+            # TypeError should be raised here for python >= 3.14:
+            inspect.get_annotations(func, eval_str=True)
 
 
 def test_suite():

--- a/src/lxml/tests/test_annotations.py
+++ b/src/lxml/tests/test_annotations.py
@@ -45,7 +45,8 @@ class TypingTestCase(HelperTestCase):
         # Test that all generic types can be subscripted.
         # Based on PEP 560.
         func = container_function_with_subscripted_types()
-        inspect.get_annotations(func, eval_str=True)
+        if sys.version_info >= (3, 10):
+            inspect.get_annotations(func, eval_str=True)
 
         # Subscripting etree.Element should fail with the error:
         # TypeError: 'type' _ElementTree is not subscriptable


### PR DESCRIPTION
Some classes like lxml.etree.ElementTree are generic types that can contain different kinds of elements. The type of these elements has to be specified in type annotations. For example:

element_tree: lxml.etree.ElementTree[lxml.etree.Element]

This requires adding a __class_getitem__ class method to these class, as specified in PEP 560. This commit adds these class methods.

The list of generic types in lxml was taken from:

https://github.com/abelcheung/types-lxml/wiki/Using-specialised-class-directly

This PR is a reincarnation of PR #401. The difference is that now there is no reference to private classes anymore.