### PR TITLE
Fix expected messages for XPath namespace errors

### DIFF
--- a/doc/extensions.txt
+++ b/doc/extensions.txt
@@ -249,7 +249,7 @@ the global mapping of the FunctionNamespace objects:
   >>> e2('/foo:a')
   Traceback (most recent call last):
   ...
-  lxml.etree.XPathEvalError: Undefined namespace prefix
+  lxml.etree.XPathEvalError: Undefined namespace prefix...
 
 
 Evaluator-local extensions

--- a/doc/xpathxslt.txt
+++ b/doc/xpathxslt.txt
@@ -412,7 +412,7 @@ During evaluation, lxml will emit an XPathEvalError on errors:
   >>> find(root)
   Traceback (most recent call last):
     ...
-  lxml.etree.XPathEvalError: Undefined namespace prefix
+  lxml.etree.XPathEvalError: Undefined namespace prefix...
 
 This works for the ``XPath`` class, however, the other evaluators (including
 the ``xpath()`` method) are one-shot operations that do parsing and evaluation
@@ -429,7 +429,7 @@ in one step.  They therefore raise evaluation exceptions in all cases:
   >>> find = root.xpath("//ns:a")
   Traceback (most recent call last):
     ...
-  lxml.etree.XPathEvalError: Undefined namespace prefix
+  lxml.etree.XPathEvalError: Undefined namespace prefix...
 
   >>> find = root.xpath("\\")
   Traceback (most recent call last):

--- a/src/lxml/tests/common_imports.py
+++ b/src/lxml/tests/common_imports.py
@@ -104,7 +104,7 @@ doctest_parser = doctest.DocTestParser()
 
 def make_doctest(filename):
     file_path = os.path.join(DOC_DIR, filename)
-    return doctest.DocFileSuite(file_path, module_relative=False, encoding='utf-8')
+    return doctest.DocFileSuite(file_path, module_relative=False, encoding='utf-8', optionflags=doctest.ELLIPSIS)
 
 
 class HelperTestCase(unittest.TestCase):


### PR DESCRIPTION
libxml2 2.15 adds additional detail to some XPath error messages, for example the actual name of undefined prefixes, functions or variables. Use the doctest.ELLIPSIS option to handle such messages.