### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["Cython>=3.1.2", "setuptools", "wheel"]
+requires = ["Cython>=3.1.2", "setuptools"]
 
 [tool.cibuildwheel]
 build-verbosity = 1


### PR DESCRIPTION
- current version of setuptools (70.1+) does not need wheel at all
- older versions of setuptools would fetch wheel when building wheels (but not sdists)