### PR TITLE
fix: setuptools deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,6 @@ build the sources, see the build instructions on the project home page.
         versioninfo.dev_status(),
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Cython',
         # NOTE: keep in sync with 'python_requires' list above.
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
When building with a recent version of setuptools, it emits a deprecation warning, e.g.:

```
SetuptoolsDeprecationWarning: License classifiers are deprecated. !!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```

setuptools' [documentation][0] explains the required changes.

Please note that I did not add `license-files`, because this is not recognised in older setuptools versions and will fail to build.

[0]: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files