### PR TITLE
Build Python 3.14 wheels, declare support

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
         # Nb. keep cibuildwheel version pin consistent with job below
-        run: pipx install cibuildwheel==2.22.0
+        run: pipx install cibuildwheel==3.1.3
       - id: set-matrix
         run: |
           MATRIX=$(
@@ -138,13 +138,13 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.1
+        uses: pypa/cibuildwheel@v3.1.3
         with:
           only: ${{ matrix.only }}
 
       - name: Build old Linux wheels
         if: contains(matrix.only, '-manylinux_') && (contains(matrix.only, 'i686') || contains(matrix.only, 'x86_64') || contains(matrix.only, 'aarch64'))
-        uses: pypa/cibuildwheel@v3.0.1
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_MANYLINUX_i686_IMAGE: manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -155,7 +155,7 @@ jobs:
       - name: Build faster Linux wheels
         # also build wheels with the most recent manylinux images and gcc
         if: runner.os == 'Linux' && !contains(matrix.only, 'i686')
-        uses: pypa/cibuildwheel@v3.0.1
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,7 @@ build the sources, see the build instructions on the project home page.
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Programming Language :: C',
         'Operating System :: OS Independent',
         'Topic :: Text Processing :: Markup :: HTML',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38, py39, py310, py311, py312, py313
+envlist = py38, py39, py310, py311, py312, py313, py314
 
 [testenv]
 allowlist_externals = make


### PR DESCRIPTION
Depends on https://github.com/lxml/lxml/pull/473
Fixes https://bugs.launchpad.net/lxml/+bug/2119130

This overlaps with #472, but that PR misses the cibuildwheel Python package. Without it Python 3.14 is not included in the build matrix.

The test `lxml.html.tests.test_elementsoup.SoupParserTestCase.test_wrap_html` will fail on Python 3.14 until #473 (or another fix for https://bugs.launchpad.net/lxml/+bug/2119510) is merged.