### PR TITLE
Fix typo: `type annotions` -> `type annotations` in PEP 560 comments

### DIFF
--- a/src/lxml/builder.py
+++ b/src/lxml/builder.py
@@ -234,7 +234,7 @@ class ElementMaker:
     def __getattr__(self, tag):
         return partial(self, tag)
 
-    # Allow subscripting ElementMaker in type annotions (PEP 560)
+    # Allow subscripting ElementMaker in type annotations (PEP 560)
     def __class_getitem__(cls, item):
         return _GenericAlias(cls, item)
 

--- a/src/lxml/parser.pxi
+++ b/src/lxml/parser.pxi
@@ -1773,7 +1773,7 @@ cdef class XMLParser(_FeedParser):
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding, resolve_external)
 
-    # Allow subscripting XMLParser in type annotions (PEP 560)
+    # Allow subscripting XMLParser in type annotations (PEP 560)
     def __class_getitem__(cls, item):
         return _GenericAlias(cls, item)
 
@@ -1964,7 +1964,7 @@ cdef class HTMLParser(_FeedParser):
                              remove_comments, remove_pis, strip_cdata,
                              collect_ids, target, encoding)
 
-    # Allow subscripting HTMLParser in type annotions (PEP 560)
+    # Allow subscripting HTMLParser in type annotations (PEP 560)
     def __class_getitem__(cls, item):
         return _GenericAlias(cls, item)
 

--- a/src/lxml/sax.py
+++ b/src/lxml/sax.py
@@ -158,7 +158,7 @@ class ElementTreeContentHandler(ContentHandler):
 
     ignorableWhitespace = characters
 
-    # Allow subscripting sax.ElementTreeContentHandler in type annotions (PEP 560)
+    # Allow subscripting sax.ElementTreeContentHandler in type annotations (PEP 560)
     def __class_getitem__(cls, item):
         return _GenericAlias(cls, item)
 


### PR DESCRIPTION
The comment `# Allow subscripting <Class> in type annotions (PEP 560)` was copy-pasted to four locations with the same typo (`annotions` instead of `annotations`). Fixed in `builder.py`, `parser.pxi` (twice) and `sax.py`.

Comment-only change, no behavioural impact.