### PR TITLE
Avoid NameError in doctestcompare when parser fails

### DIFF
--- a/src/lxml/doctestcompare.py
+++ b/src/lxml/doctestcompare.py
@@ -404,8 +404,13 @@ def temp_install(html=False, del_module=None):
     check_func = frame.f_locals['check'].__func__
     checker_check_func = checker.check_output.__func__
     # Because we can't patch up func_globals, this is the only global
-    # in check_output that we care about:
-    doctest.etree = etree
+    # in check_output that we care about.  We inject it directly into the
+    # function's actual globals dict, which is not necessarily
+    # doctest.__dict__: when the active runner uses a checker whose
+    # check_output is defined in another module (e.g. pytest's doctest
+    # plugin or any OutputChecker subclass), those globals belong to that
+    # module instead.
+    check_func.__globals__['etree'] = etree
     _RestoreChecker(dt_self, old_checker, checker,
                     check_func, checker_check_func,
                     del_module)

--- a/src/lxml/tests/test_doctestcompare.py
+++ b/src/lxml/tests/test_doctestcompare.py
@@ -1,4 +1,5 @@
 import unittest
+import doctest
 
 from lxml import etree
 from .common_imports import HelperTestCase
@@ -9,6 +10,15 @@ class DummyInput:
     def __init__(self, **kw):
         for name, value in kw.items():
             setattr(self, name, value)
+
+
+class _PlainChecker(doctest.OutputChecker):
+    # Defined here (not in the doctest module) so that its check_output
+    # runs against this module's globals rather than doctest.__dict__.
+    # This mirrors a third-party or subclassed checker (e.g. pytest's
+    # doctest plugin), which is the case the temp_install() fix must handle.
+    def check_output(self, want, got, optionflags):
+        return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 
 def indent(elem, level=0):
@@ -118,6 +128,32 @@ class DoctestCompareTest(HelperTestCase):
             '<p>\n'
             '  <span class="foo" -id="bar">Text</span>\n'
             '</p>\n')
+
+    def test_temp_install_parse_error_no_nameerror(self):
+        # Regression test for https://bugs.launchpad.net/lxml/+bug/2143321
+        # When temp_install() clones check_output into the doctest runner,
+        # a parser failure must be reported as a normal doctest failure and
+        # must not raise NameError because 'etree' is missing from the globals
+        # of the runner's check function.  The stock doctest OutputChecker
+        # has its check_output defined in the doctest module, so its globals
+        # happen to be doctest.__dict__ and mask the bug; a checker defined
+        # elsewhere (as here, and as with pytest's doctest plugin) exercises
+        # the failing path.
+        if hasattr(doctest, 'etree'):
+            # Drop any stale injection from an earlier doctest run so it
+            # cannot hide a regression here.
+            del doctest.etree
+        runner = doctest.DocTestRunner(checker=_PlainChecker(), verbose=False)
+        parser = doctest.DocTestParser()
+        test = parser.get_doctest(
+            '>>> from lxml.doctestcompare import temp_install\n'
+            '>>> temp_install()\n'
+            '>>> print("<root>")\n'
+            '<root><b />\n',
+            {}, 'nameerror_regression', 'nameerror_regression.txt', 0)
+        result = runner.run(test)
+        self.assertEqual(result.attempted, 3)
+        self.assertEqual(result.failed, 1)
 
 
 def test_suite():


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/lxml/+bug/2143321

When temp_install() clones LXMLOutputChecker.check_output into the doctest runner's check function, the exception handler references etree.XMLSyntaxError. The old code set doctest.etree, which only works when the runner's check function globals happen to be `doctest.__dict__`. That is true for the stock OutputChecker, but not when the active runner uses a checker whose check_output is defined in another module (for example pytest's doctest plugin, or any OutputChecker subclass): there the clone runs against that other module's globals and raises NameError: name 'etree' is not defined.

Injecting etree directly into the check function's actual `__globals__` dict covers every invocation path.

Adds a regression test that drives the doctest through a checker defined outside the doctest module (so the failing path is actually exercised) and asserts the parse failure is reported as a normal doctest failure rather than raising NameError.