### PR TITLE
Fix bare except: use specific exception types in Python scripts

### DIFF
--- a/buildlibxml.py
+++ b/buildlibxml.py
@@ -22,7 +22,7 @@ try:
         if cpus > 5:
             cpus = 5
         multi_make_options = ['-j%d' % (cpus+1)]
-except:
+except Exception:
     pass
 
 

--- a/doc/rest2html.py
+++ b/doc/rest2html.py
@@ -12,7 +12,7 @@ INLINESTYLES = False
 try:
     import locale
     locale.setlocale(locale.LC_ALL, '')
-except:
+except Exception:
     pass
 
 # set up Pygments

--- a/download_artefacts.py
+++ b/download_artefacts.py
@@ -70,7 +70,7 @@ def download1(wheel_metadata, dest_dir):
         try:
             with open(temp_file_path, "wb") as f:
                 shutil.copyfileobj(w, f)
-        except:
+        except Exception:
             if temp_file_path.exists():
                 temp_file_path.unlink()
             raise

--- a/download_artefacts.py
+++ b/download_artefacts.py
@@ -70,7 +70,7 @@ def download1(wheel_metadata, dest_dir):
         try:
             with open(temp_file_path, "wb") as f:
                 shutil.copyfileobj(w, f)
-        except Exception:
+        except:
             if temp_file_path.exists():
                 temp_file_path.unlink()
             raise


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types in pure Python files:

- `doc/rest2html.py`: `except Exception:` (guards `locale.setlocale()` call)
- `download_artefacts.py`: `except Exception:` (guards `shutil.copyfileobj()` during download)
- `buildlibxml.py`: `except Exception:` (guards CPU count via `multiprocessing`)

Bare `except:` catches `BaseException` including `SystemExit` and `KeyboardInterrupt`, which can suppress intended program termination.